### PR TITLE
Add av_jni_set_java_vm for android

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -1,0 +1,18 @@
+use core::ffi::{c_int, c_void};
+
+#[link(name = "avcodec")]
+extern "C" {
+    fn av_jni_set_java_vm(
+       vm:  *mut c_void,
+       ctx: *mut c_void,
+    ) -> c_int;
+}
+
+pub fn ffmpeg_set_java_vm(vm: *mut c_void) {
+    unsafe {
+        av_jni_set_java_vm(
+            vm as _,
+            std::ptr::null_mut() as _,
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod ffmpeg_ram;
 pub mod mux;
 #[cfg(all(windows, feature = "vram"))]
 pub mod vram;
+#[cfg(target_os = "android")]
+pub mod android;
 
 #[no_mangle]
 pub extern "C" fn hwcodec_log(level: i32, message: *const std::os::raw::c_char) {


### PR DESCRIPTION
FFmpeg needs JVM handle for "*_mediacodec" codecs to work on Android:

https://groups.google.com/g/javacpp-project/c/pYGBhqSEvcU

but this was never set.

This change + companion one in RD core == tested working hardware encoding and decoding on Android and Debian devices.
