### PR TITLE
disable ffmpeg qsv vram encode because of memory leak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hwcodec"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 | GPU           | FFmpeg ram        | FFmpeg vram | sdk vram |
 | ------------- | ----------------  | ----------- | -------- |
-| intel encode  | qsv               | qsv         | Y        |
+| intel encode  | qsv               |             | Y        |
 | intel decode  | d3d11             | d3d11       | Y        |
 | nvidia encode | nvenc(nv12->d3d11)| nvenc(d3d11)| Y        |
 | nvidia decode | d3d11             | d3d11       | N        |
@@ -23,6 +23,8 @@ Based on the information above, there are several optimizations and changes made
   - SDK decoding with CUDA acceleration: The CUDA acceleration support is disabled.
 
 * amd sdk remove h265 support, https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/432
+
+* ffmpeg qsv vram encode is not well implemented, has memory leak issue
 
 ### Linux
 

--- a/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
@@ -493,8 +493,8 @@ int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum,
   try {
     AdapterDesc *descs = (AdapterDesc *)outDescs;
     int count = 0;
-    AdapterVendor vendors[] = {ADAPTER_VENDOR_INTEL, ADAPTER_VENDOR_NVIDIA,
-                               ADAPTER_VENDOR_AMD};
+    // qsv has memory leak issue, add it back after fixed
+    AdapterVendor vendors[] = {ADAPTER_VENDOR_NVIDIA, ADAPTER_VENDOR_AMD};
     for (auto vendor : vendors) {
       Adapters adapters;
       if (!adapters.Init(vendor))


### PR DESCRIPTION
Intel gpu use sdk vram mfx.

Codec| h264/h265 switch 30 times | disconnect |  h264/h265 switch 30 times again | disconnect
-- | -- | -- | -- | --
vpx (switch between vp8,vp9) | 330M | 14M | 330M | 15M
FFmpeg vram qsv | 1.39G | 1.29G | 2.64G | 2.55G
FFmpeg vram nvenc | 56M | 15M | 61M | 17M
FFmpeg vram amf | 32M | 16M | 33M | 16M
sdk vram mfx | 121M | 14M | 149M | 41M
sdk vram nvnec | 59M | 24M | 66M | 28M
sdk vram amf | 31M | 14M | 31M | 12M
FFmpeg ram qsv | 126M | 13.9M | 133M | 40M
FFmpeg ram nvnec | 83M | 17M | 90M | 29M
FFmpeg ram amf | 69M | 12M | 70M | 12.9M

