### PR TITLE
fix, check ffmpeg encoded packet size

### DIFF
--- a/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
@@ -350,6 +350,10 @@ private:
         }
         goto _exit;
       }
+      if (!pkt_->data || !pkt_->size) {
+        LOG_ERROR("avcodec_receive_packet failed, pkt size is 0");
+        goto _exit;
+      }
       encoded = true;
       callback_(pkt_->data, pkt_->size, pkt_->pts,
                 pkt_->flags & AV_PKT_FLAG_KEY, obj);

--- a/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
@@ -325,6 +325,10 @@ private:
         }
         goto _exit;
       }
+      if (!pkt_->data || !pkt_->size) {
+        LOG_ERROR("avcodec_receive_packet failed, pkt size is 0");
+        goto _exit;
+      }
       encoded = true;
       if (callback)
         callback(pkt_->data, pkt_->size, pkt_->flags & AV_PKT_FLAG_KEY, obj,


### PR DESCRIPTION
Fix https://github.com/rustdesk/rustdesk-server-pro/discussions/382#discussioncomment-10525997

sdk already checked

https://github.com/rustdesk-org/hwcodec/blob/6abd1898f3a03481ed0c038507b5218d6ea94267/cpp/mfx/mfx_encode.cpp#L480

https://github.com/rustdesk-org/hwcodec/blob/6abd1898f3a03481ed0c038507b5218d6ea94267/cpp/nv/nv_encode.cpp#L198

https://github.com/rustdesk-org/hwcodec/blob/6abd1898f3a03481ed0c038507b5218d6ea94267/cpp/amf/amf_encode.cpp#L143