### PR TITLE
Add size to vram decode callback

### DIFF
--- a/cpp/common/platform/win/win.cpp
+++ b/cpp/common/platform/win/win.cpp
@@ -737,3 +737,11 @@ uint64_t GetHwcodecGpuSignature() {
   }
   return signature;
 }
+
+void hwcodec_get_d3d11_texture_width_height(ID3D11Texture2D *texture, int *w,
+                                             int *h) {
+  D3D11_TEXTURE2D_DESC desc;
+  texture->GetDesc(&desc);
+  *w = desc.Width;
+  *h = desc.Height;
+}

--- a/cpp/common/platform/win/win.h
+++ b/cpp/common/platform/win/win.h
@@ -127,4 +127,7 @@ public:
 
 extern "C" uint64_t GetHwcodecGpuSignature();
 
+extern "C" void hwcodec_get_d3d11_texture_width_height(ID3D11Texture2D *texture, int *w,
+                                             int *h);
+
 #endif

--- a/cpp/mux/mux.cpp
+++ b/cpp/mux/mux.cpp
@@ -44,6 +44,8 @@ public:
   bool init(const char *filename, int width, int height, int is265,
             int framerate) {
     OutputStream *ost = &video_st;
+    ost->st = NULL;
+    ost->tmp_pkt = NULL;
     int ret;
 
     if ((ret = avformat_alloc_output_context2(&oc, NULL, NULL, filename)) < 0) {

--- a/examples/pipeline_vram.rs
+++ b/examples/pipeline_vram.rs
@@ -51,6 +51,7 @@ fn main() {
         let mut dup_sum = Duration::ZERO;
         let mut enc_sum = Duration::ZERO;
         let mut dec_sum = Duration::ZERO;
+        let mut pts_instant = Instant::now();
         loop {
             let start = Instant::now();
             let texture = capturer.capture(100);
@@ -59,7 +60,9 @@ fn main() {
             }
             dup_sum += start.elapsed();
             let start = Instant::now();
-            let frame = enc.encode(texture).unwrap();
+            let frame = enc
+                .encode(texture, pts_instant.elapsed().as_millis() as _)
+                .unwrap();
             enc_sum += start.elapsed();
             for f in frame {
                 file.write_all(&mut f.data).unwrap();


### PR DESCRIPTION
1. Get width/height information from vram decoding.
2. Fix the problem of destroying muxer crash when android does not have external storage permission, which occurs in the new version, but does not occur at nightly.