### PR TITLE
hevc, return decode failure when "Could not find ref with POC" happens

### DIFF
--- a/cpp/amf/amf_decode.cpp
+++ b/cpp/amf/amf_decode.cpp
@@ -386,11 +386,13 @@ int amf_decode(void *decoder, uint8_t *data, int32_t length,
                DecodeCallback callback, void *obj) {
   try {
     AMFDecoder *dec = (AMFDecoder *)decoder;
-    return -dec->decode(data, length, callback, obj);
+    if (dec->decode(data, length, callback, obj) == AMF_OK) {
+      return HWCODEC_SUCCESS;
+    }
   } catch (const std::exception &e) {
     LOG_ERROR("decode failed: " + e.what());
   }
-  return -1;
+  return HWCODEC_ERR_COMMON;
 }
 
 int amf_test_decode(AdapterDesc *outDescs, int32_t maxDescNum,

--- a/cpp/common/common.h
+++ b/cpp/common/common.h
@@ -43,4 +43,10 @@ enum RateControl {
   RC_CQ,
 };
 
+enum HwcodecErrno {
+  HWCODEC_SUCCESS = 0,
+  HWCODEC_ERR_COMMON = -1,
+  HWCODEC_ERR_HEVC_COULD_NOT_FIND_POC = -2,
+};
+
 #endif // COMMON_H

--- a/cpp/common/ffmpeg_ffi.h
+++ b/cpp/common/ffmpeg_ffi.h
@@ -18,5 +18,7 @@ enum AVPixelFormat {
 
 int av_log_get_level(void);
 void av_log_set_level(int level);
+void hwcodec_set_av_log_callback();
+void hwcodec_set_flag_could_not_find_ref_with_poc();
 
 #endif

--- a/cpp/common/log.cpp
+++ b/cpp/common/log.cpp
@@ -1,6 +1,8 @@
 
 #include "log.h"
-
+extern "C" {
+  #include <libavutil/log.h>
+}
 namespace gol {
 enum {
   LOG_LEVEL_ERROR = 0,
@@ -11,6 +13,7 @@ enum {
 };
 
 extern "C" void hwcodec_log(int level, const char *message);
+extern "C" void hwcodec_av_log_callback(int level, const char *message);
 
 void log_to_rust(int level, const std::string &message) {
   const char *cstr = message.c_str();
@@ -33,4 +36,18 @@ void trace(const std::string &message) {
   log_to_rust(LOG_LEVEL_TRACE, message);
 }
 
+void av_log_callback(void *ptr, int level, const char *fmt, va_list vl) {
+  if (level > av_log_get_level()) {
+    return;
+  }
+  char line[1024] = {0};
+  vsnprintf(line, sizeof(line), fmt, vl);
+  hwcodec_av_log_callback(level, line);
+};
+
 } // namespace gol
+
+
+extern "C" void hwcodec_set_av_log_callback() {
+  av_log_set_callback(gol::av_log_callback);
+}

--- a/cpp/common/uitl.h
+++ b/cpp/common/uitl.h
@@ -7,7 +7,7 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 }
 
-namespace util {
+namespace util_encode {
 
 void set_av_codec_ctx(AVCodecContext *c, const std::string &name, int kbs,
                       int gop, int fps);
@@ -22,5 +22,9 @@ bool set_others(void *priv_data, const std::string &name);
 bool change_bit_rate(AVCodecContext *c, const std::string &name, int kbs);
 
 } // namespace util
+
+namespace util_decode {
+    bool has_flag_could_not_find_ref_with_poc();
+}
 
 #endif

--- a/cpp/common/util.cpp
+++ b/cpp/common/util.cpp
@@ -15,7 +15,7 @@ extern "C" {
 #define LOG_MODULE "UTIL"
 #include "log.h"
 
-namespace util {
+namespace util_encode {
 
 void set_av_codec_ctx(AVCodecContext *c, const std::string &name, int kbs,
                       int gop, int fps) {
@@ -299,4 +299,21 @@ bool change_bit_rate(AVCodecContext *c, const std::string &name, int kbs) {
   }
   return true;
 }
-} // namespace util
+
+} // namespace util_encode
+
+namespace util_decode {
+
+static bool g_flag_could_not_find_ref_with_poc = false;
+
+bool has_flag_could_not_find_ref_with_poc() {
+  bool v = g_flag_could_not_find_ref_with_poc;
+  g_flag_could_not_find_ref_with_poc = false;
+  return v;
+}
+
+} // namespace util_decode
+
+extern "C" void hwcodec_set_flag_could_not_find_ref_with_poc() {
+  util_decode::g_flag_could_not_find_ref_with_poc = true;
+}

--- a/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
@@ -228,16 +228,16 @@ public:
     c_->pix_fmt =
         hw_pixfmt_ != AV_PIX_FMT_NONE ? hw_pixfmt_ : (AVPixelFormat)pixfmt_;
     c_->sw_pix_fmt = (AVPixelFormat)pixfmt_;
-    util::set_av_codec_ctx(c_, name_, kbs_, gop_, fps_);
-    if (!util::set_lantency_free(c_->priv_data, name_)) {
+    util_encode::set_av_codec_ctx(c_, name_, kbs_, gop_, fps_);
+    if (!util_encode::set_lantency_free(c_->priv_data, name_)) {
       LOG_ERROR("set_lantency_free failed, name: " + name_);
       return false;
     }
-    // util::set_quality(c_->priv_data, name_, quality_);
-    util::set_rate_control(c_, name_, rc_, q_);
-    util::set_gpu(c_->priv_data, name_, gpu_);
-    util::force_hw(c_->priv_data, name_);
-    util::set_others(c_->priv_data, name_);
+    // util_encode::set_quality(c_->priv_data, name_, quality_);
+    util_encode::set_rate_control(c_, name_, rc_, q_);
+    util_encode::set_gpu(c_->priv_data, name_, gpu_);
+    util_encode::force_hw(c_->priv_data, name_);
+    util_encode::set_others(c_->priv_data, name_);
     if (name_.find("mediacodec") != std::string::npos) {
       if (mc_name_.length() > 0) {
         LOG_INFO("mediacodec codec_name: " + mc_name_);
@@ -302,7 +302,7 @@ public:
   }
 
   int set_bitrate(int kbs) {
-    return util::change_bit_rate(c_, name_, kbs) ? 0 : -1;
+    return util_encode::change_bit_rate(c_, name_, kbs) ? 0 : -1;
   }
 
 private:

--- a/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
@@ -81,7 +81,6 @@ public:
   const int align_ = 0;
   const bool full_range_ = false;
   const bool bt709_ = false;
-
   FFmpegVRamEncoder(void *handle, int64_t luid, API api, DataFormat dataFormat,
                     int32_t width, int32_t height, int32_t kbs,
                     int32_t framerate, int32_t gop) {
@@ -132,12 +131,13 @@ public:
     c_->height = height_;
     c_->pix_fmt = encoder_->hw_pixfmt_;
     c_->sw_pix_fmt = encoder_->sw_pixfmt_;
-    util::set_av_codec_ctx(c_, encoder_->name_, kbs_, gop_, framerate_);
-    if (!util::set_lantency_free(c_->priv_data, encoder_->name_)) {
+    util_encode::set_av_codec_ctx(c_, encoder_->name_, kbs_, gop_, framerate_);
+    if (!util_encode::set_lantency_free(c_->priv_data, encoder_->name_)) {
       return false;
     }
-    // util::set_quality(c_->priv_data, encoder_->name_, Quality_Default);
-    util::set_rate_control(c_, encoder_->name_, RC_CBR, -1);
+    // util_encode::set_quality(c_->priv_data, encoder_->name_, Quality_Default);
+    util_encode::set_rate_control(c_, encoder_->name_, RC_CBR, -1);
+    util_encode::set_others(c_->priv_data, encoder_->name_);
 
     hw_device_ctx_ = av_hwdevice_ctx_alloc(encoder_->device_type_);
     if (!hw_device_ctx_) {
@@ -254,7 +254,7 @@ public:
   }
 
   int set_bitrate(int kbs) {
-    return util::change_bit_rate(c_, encoder_->name_, kbs) ? 0 : -1;
+    return util_encode::change_bit_rate(c_, encoder_->name_, kbs) ? 0 : -1;
   }
 
   int set_framerate(int framerate) {

--- a/cpp/mfx/mfx_decode.cpp
+++ b/cpp/mfx/mfx_decode.cpp
@@ -431,11 +431,13 @@ int mfx_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
                void *obj) {
   try {
     VplDecoder *p = (VplDecoder *)decoder;
-    return p->decode(data, len, callback, obj);
+    if (p->decode(data, len, callback, obj) == 0) {
+      return HWCODEC_SUCCESS;
+    }
   } catch (const std::exception &e) {
     LOG_ERROR("decode failed: " + e.what());
   }
-  return -1;
+  return HWCODEC_ERR_COMMON;
 }
 
 int mfx_test_decode(AdapterDesc *outDescs, int32_t maxDescNum,

--- a/cpp/nv/nv_decode.cpp
+++ b/cpp/nv/nv_decode.cpp
@@ -643,11 +643,13 @@ int nv_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
               void *obj) {
   try {
     CuvidDecoder *p = (CuvidDecoder *)decoder;
-    return p->decode(data, len, callback, obj);
+    if (p->decode(data, len, callback, obj) == 0 ) {
+      return HWCODEC_SUCCESS;
+    }
   } catch (const std::exception &e) {
     LOG_ERROR("decode failed" + e.what());
   }
-  return -1;
+  return HWCODEC_ERR_COMMON;
 }
 
 int nv_test_decode(AdapterDesc *outDescs, int32_t maxDescNum,

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -20,7 +20,7 @@ fn main() {
         mc_name: None,
         width: 1920,
         height: 1080,
-        pixfmt: AVPixelFormat::AV_PIX_FMT_YUV420P,
+        pixfmt: AVPixelFormat::AV_PIX_FMT_NV12,
         align: 0,
         kbs: 5000,
         fps: 30,
@@ -30,12 +30,12 @@ fn main() {
         thread_count: 4,
         q: -1,
     };
-    let yuv_count = 100;
+    let yuv_count = 10;
     println!("benchmark");
     let yuvs = prepare_yuv(ctx.width as _, ctx.height as _, yuv_count);
 
-    println!("encoders:");
     let encoders = Encoder::available_encoders(ctx.clone(), None);
+    log::info!("encoders: {:?}", encoders);
     let best = CodecInfo::prioritized(encoders.clone());
     for info in encoders {
         test_encoder(info.clone(), ctx.clone(), &yuvs, is_best(&best, &info));
@@ -43,8 +43,8 @@ fn main() {
 
     let (h264s, h265s) = prepare_h26x(best, ctx.clone(), &yuvs);
 
-    println!("decoders:");
     let decoders = Decoder::available_decoders(None);
+    log::info!("decoders: {:?}", decoders);
     let best = CodecInfo::prioritized(decoders.clone());
     for info in decoders {
         let h26xs = if info.name.contains("h264") {

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -22,3 +22,38 @@ pub enum AVHWDeviceType {
     AV_HWDEVICE_TYPE_MEDIACODEC,
     AV_HWDEVICE_TYPE_VULKAN,
 }
+
+#[no_mangle]
+pub extern "C" fn hwcodec_av_log_callback(level: i32, message: *const std::os::raw::c_char) {
+    let could_not_find_ref_with_poc = "Could not find ref with POC";
+    unsafe {
+        let c_str = std::ffi::CStr::from_ptr(message);
+        if let Ok(str_slice) = c_str.to_str() {
+            let string = String::from(str_slice);
+            if level == AV_LOG_ERROR as i32 {
+                log::error!("{}", string);
+                if string.contains(could_not_find_ref_with_poc) {
+                    hwcodec_set_flag_could_not_find_ref_with_poc();
+                }
+            } else if level == AV_LOG_PANIC as i32 || level == AV_LOG_FATAL as i32 {
+                log::error!("{}", string);
+            } else if level == AV_LOG_WARNING as i32 {
+                log::warn!("{}", string);
+            } else if level == AV_LOG_INFO as i32 {
+                log::info!("{}", string);
+            } else if level == AV_LOG_VERBOSE as i32 || level == AV_LOG_DEBUG as i32 {
+                log::debug!("{}", string);
+            } else if level == AV_LOG_TRACE as i32 {
+                log::trace!("{}", string);
+            }
+        }
+    }
+}
+
+pub(crate) fn init_av_log() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| unsafe {
+        av_log_set_level(AV_LOG_ERROR as i32);
+        hwcodec_set_av_log_callback();
+    });
+}

--- a/src/vram/decode.rs
+++ b/src/vram/decode.rs
@@ -1,8 +1,9 @@
 use crate::{
     common::{AdapterDesc, DataFormat::*, Driver::*},
+    ffmpeg::init_av_log,
     vram::{amf, ffmpeg, inner::DecodeCalls, mfx, nv, DecodeContext},
 };
-use log::{error, trace};
+use log::trace;
 use std::{
     ffi::c_void,
     sync::{Arc, Mutex},
@@ -29,6 +30,7 @@ extern "C" {
 
 impl Decoder {
     pub fn new(ctx: DecodeContext) -> Result<Self, ()> {
+        init_av_log();
         let calls = match ctx.driver {
             NV => nv::decode_calls(),
             AMF => amf::decode_calls(),
@@ -66,7 +68,6 @@ impl Decoder {
             );
 
             if ret != 0 {
-                error!("Error decode: {}", ret);
                 Err(ret)
             } else {
                 Ok(&mut *self.frames)

--- a/src/vram/encode.rs
+++ b/src/vram/encode.rs
@@ -1,5 +1,6 @@
 use crate::{
     common::{AdapterDesc, Driver::*},
+    ffmpeg::init_av_log,
     vram::{
         amf, ffmpeg, inner::EncodeCalls, mfx, nv, DynamicContext, EncodeContext, FeatureContext,
     },
@@ -25,6 +26,7 @@ unsafe impl Sync for Encoder {}
 
 impl Encoder {
     pub fn new(ctx: EncodeContext) -> Result<Self, ()> {
+        init_av_log();
         if ctx.d.width % 2 == 1 || ctx.d.height % 2 == 1 {
             return Err(());
         }


### PR DESCRIPTION
* Use ffmpeg log callback to catch the error, then set a global flag.
* Return -2 when hevc decode get this flag, however, it may not belongs to this decoder
* The upper level code should handle all hevc decoder