### PR TITLE
ensure keyframe when check available encoders

### DIFF
--- a/cpp/amf/amf_encode.cpp
+++ b/cpp/amf/amf_encode.cpp
@@ -15,6 +15,7 @@
 #include "callback.h"
 #include "common.h"
 #include "system.h"
+#include "uitl.h"
 
 #define LOG_MODULE "AMFENC"
 #include "log.h"
@@ -184,7 +185,12 @@ public:
     void *native = surface->GetPlaneAt(0)->GetNative();
     if (!native)
       return AMF_FAIL;
-    return encode(native, nullptr, nullptr, 0);
+    int32_t key_obj = 0;
+    res = encode(native, util_encode::vram_encode_test_callback, &key_obj, 0);
+    if (res == AMF_OK && key_obj == 1) {
+      return AMF_OK;
+    }
+    return AMF_FAIL;
   }
 
   AMF_RESULT initialize() {
@@ -396,8 +402,7 @@ private:
       res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT,
                                      query_timeout_); // ms
       AMF_CHECK_RETURN(
-          res, "SetProperty(AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT failed",
-          query_timeout_);
+          res, "SetProperty(AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT failed");
 
       res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE,
                                      bitRateIn_);

--- a/cpp/common/uitl.h
+++ b/cpp/common/uitl.h
@@ -20,6 +20,7 @@ bool force_hw(void *priv_data, const std::string &name);
 bool set_others(void *priv_data, const std::string &name);
 
 bool change_bit_rate(AVCodecContext *c, const std::string &name, int kbs);
+void vram_encode_test_callback(const uint8_t *data, int32_t len, int32_t key, const void *obj, int64_t pts);
 
 } // namespace util
 

--- a/cpp/common/util.cpp
+++ b/cpp/common/util.cpp
@@ -300,6 +300,16 @@ bool change_bit_rate(AVCodecContext *c, const std::string &name, int kbs) {
   return true;
 }
 
+void vram_encode_test_callback(const uint8_t *data, int32_t len, int32_t key, const void *obj, int64_t pts) {
+  (void)data;
+  (void)len;
+  (void)pts;
+  if (obj) {
+    int32_t *pkey = (int32_t *)obj;
+    *pkey = key;
+  }
+}
+
 } // namespace util_encode
 
 namespace util_decode {

--- a/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
@@ -515,8 +515,9 @@ int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum,
           continue;
         if (e->native_->EnsureTexture(e->width_, e->height_)) {
           e->native_->next();
-          if (ffmpeg_vram_encode(e, e->native_->GetCurrentTexture(), nullptr,
-                                 nullptr, 0) == 0) {
+          int32_t key_obj = 0;
+          if (ffmpeg_vram_encode(e, e->native_->GetCurrentTexture(), util_encode::vram_encode_test_callback,
+                                 &key_obj, 0) == 0 && key_obj == 1) {
             AdapterDesc *desc = descs + count;
             desc->luid = LUID(adapter.get()->desc1_);
             count += 1;

--- a/cpp/mfx/mfx_encode.cpp
+++ b/cpp/mfx/mfx_encode.cpp
@@ -8,6 +8,7 @@
 #include "callback.h"
 #include "common.h"
 #include "system.h"
+#include "uitl.h"
 
 #define LOG_MODULE "MFXENC"
 #include "log.h"
@@ -625,8 +626,9 @@ int mfx_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
         continue;
       if (e->native_->EnsureTexture(e->width_, e->height_)) {
         e->native_->next();
-        if (mfx_encode(e, e->native_->GetCurrentTexture(), nullptr, nullptr,
-                       0) == 0) {
+        int32_t key_obj = 0;
+        if (mfx_encode(e, e->native_->GetCurrentTexture(), util_encode::vram_encode_test_callback, &key_obj,
+                       0) == 0 && key_obj == 1) {
           AdapterDesc *desc = descs + count;
           desc->luid = LUID(adapter.get()->desc1_);
           count += 1;

--- a/cpp/nv/nv_encode.cpp
+++ b/cpp/nv/nv_encode.cpp
@@ -22,6 +22,7 @@ using Microsoft::WRL::ComPtr;
 #include "callback.h"
 #include "common.h"
 #include "system.h"
+#include "uitl.h"
 
 #define LOG_MODULE "NVENC"
 #include "log.h"
@@ -409,8 +410,9 @@ int nv_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
         continue;
       if (e->native_->EnsureTexture(e->width_, e->height_)) {
         e->native_->next();
-        if (nv_encode(e, e->native_->GetCurrentTexture(), nullptr, nullptr,
-                      0) == 0) {
+        int32_t key_obj = 0;
+        if (nv_encode(e, e->native_->GetCurrentTexture(), util_encode::vram_encode_test_callback, &key_obj,
+                      0) == 0 && key_obj == 1) {
           AdapterDesc *desc = descs + count;
           desc->luid = LUID(adapter.get()->desc1_);
           count += 1;

--- a/src/ffmpeg_ram/encode.rs
+++ b/src/ffmpeg_ram/encode.rs
@@ -17,7 +17,6 @@ use std::{
     slice,
     sync::{Arc, Mutex},
     thread,
-    time::Instant,
 };
 
 use super::Priority;
@@ -327,8 +326,12 @@ impl Encoder {
                         ..ctx
                     };
                     if let Ok(mut encoder) = Encoder::new(c) {
-                        if let Ok(_) = encoder.encode(&yuv, 0) {
-                            infos.lock().unwrap().push(codec);
+                        if let Ok(frames) = encoder.encode(&yuv, 0) {
+                            if frames.len() == 1 {
+                                if frames[0].key == 1 {
+                                    infos.lock().unwrap().push(codec);
+                                }
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
Ensure the first frame has the keyframe flag. This may not be the reason of "waiting for image", but check it since we use the keyframe flag.

pc: intel && nvidia
![1733913155661](https://github.com/user-attachments/assets/4286b82f-4720-4c99-9b0b-aaba0836457f)

pc: amd
![amdpng](https://github.com/user-attachments/assets/bd253378-84f3-4bfe-abc7-58cb37673a27)
