### PR TITLE
ffmpeg vram use sdk available, add test timeout

### DIFF
--- a/cpp/amf/amf_decode.cpp
+++ b/cpp/amf/amf_decode.cpp
@@ -12,6 +12,7 @@
 #include "callback.h"
 #include "common.h"
 #include "system.h"
+#include "util.h"
 
 #define LOG_MODULE "AMFDEC"
 #include "log.h"
@@ -395,9 +396,9 @@ int amf_decode(void *decoder, uint8_t *data, int32_t length,
   return HWCODEC_ERR_COMMON;
 }
 
-int amf_test_decode(AdapterDesc *outDescs, int32_t maxDescNum,
-                    int32_t *outDescNum, API api, DataFormat dataFormat,
-                    uint8_t *data, int32_t length) {
+int amf_test_decode(AdapterDesc *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                    const int64_t *luid_range, int32_t luid_range_count,
+                    API api, DataFormat dataFormat, uint8_t *data, int32_t length) {
   try {
     AdapterDesc *descs = (AdapterDesc *)outDescs;
     Adapters adapters;
@@ -409,16 +410,19 @@ int amf_test_decode(AdapterDesc *outDescs, int32_t maxDescNum,
           nullptr, LUID(adapter.get()->desc1_), api, dataFormat);
       if (!p)
         continue;
-      if (p->decode(data, length, nullptr, nullptr) == AMF_OK) {
+      auto start = util::now();
+      bool succ = p->decode(data, length, nullptr, nullptr) == AMF_OK;
+      int64_t elapsed = util::elapsed_ms(start);
+      if (succ && elapsed < TEST_TIMEOUT_MS) {
         AdapterDesc *desc = descs + count;
         desc->luid = LUID(adapter.get()->desc1_);
         count += 1;
-        p->destroy();
-        delete p;
-        p = nullptr;
-        if (count >= maxDescNum)
-          break;
       }
+      p->destroy();
+      delete p;
+      p = nullptr;
+      if (count >= maxDescNum)
+        break;
     }
     *outDescNum = count;
     return 0;

--- a/cpp/amf/amf_encode.cpp
+++ b/cpp/amf/amf_encode.cpp
@@ -15,7 +15,7 @@
 #include "callback.h"
 #include "common.h"
 #include "system.h"
-#include "uitl.h"
+#include "util.h"
 
 #define LOG_MODULE "AMFENC"
 #include "log.h"
@@ -186,8 +186,10 @@ public:
     if (!native)
       return AMF_FAIL;
     int32_t key_obj = 0;
+    auto start = util::now();
     res = encode(native, util_encode::vram_encode_test_callback, &key_obj, 0);
-    if (res == AMF_OK && key_obj == 1) {
+    int64_t elapsed = util::elapsed_ms(start);
+    if (res == AMF_OK && key_obj == 1 && elapsed < TEST_TIMEOUT_MS) {
       return AMF_OK;
     }
     return AMF_FAIL;
@@ -529,6 +531,7 @@ int amf_driver_support() {
 }
 
 int amf_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                    const int64_t *luid_range, int32_t luid_range_count,
                     API api, DataFormat dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
                     int32_t gop) {

--- a/cpp/amf/amf_ffi.h
+++ b/cpp/amf/amf_ffi.h
@@ -24,11 +24,13 @@ int amf_decode(void *decoder, uint8_t *data, int32_t length,
 int amf_destroy_decoder(void *decoder);
 
 int amf_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                    const int64_t *luid_range, int32_t luid_range_count,
                     int32_t api, int32_t dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
                     int32_t gop);
 
 int amf_test_decode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                    const int64_t *luid_range, int32_t luid_range_count,
                     int32_t api, int32_t dataFormat, uint8_t *data,
                     int32_t length);
 

--- a/cpp/common/common.h
+++ b/cpp/common/common.h
@@ -5,6 +5,8 @@
 
 #define MAX_GOP 0x7FFFFFFF // i32 max
 
+#define TEST_TIMEOUT_MS 300
+
 enum AdapterVendor {
   ADAPTER_VENDOR_AMD = 0x1002,
   ADAPTER_VENDOR_INTEL = 0x8086,

--- a/cpp/common/util.cpp
+++ b/cpp/common/util.cpp
@@ -2,7 +2,7 @@ extern "C" {
 #include <libavutil/opt.h>
 }
 
-#include "uitl.h"
+#include "util.h"
 #include <limits>
 #include <map>
 #include <string.h>
@@ -326,4 +326,17 @@ bool has_flag_could_not_find_ref_with_poc() {
 
 extern "C" void hwcodec_set_flag_could_not_find_ref_with_poc() {
   util_decode::g_flag_could_not_find_ref_with_poc = true;
+}
+
+namespace util {
+bool luid_in_range(int64_t luid, const int64_t *luid_range, int32_t luid_range_count) {
+  if (!luid_range || luid_range_count == 0)
+    return false;
+  for (int i = 0; i < luid_range_count; i++) {
+    if (luid == luid_range[i]) {
+      return true;
+    }
+  }
+  return false;
+}
 }

--- a/cpp/common/util.h
+++ b/cpp/common/util.h
@@ -2,7 +2,7 @@
 #define UTIL_H
 
 #include <string>
-
+#include <chrono>
 extern "C" {
 #include <libavcodec/avcodec.h>
 }
@@ -27,5 +27,19 @@ void vram_encode_test_callback(const uint8_t *data, int32_t len, int32_t key, co
 namespace util_decode {
     bool has_flag_could_not_find_ref_with_poc();
 }
+
+namespace util {
+
+    inline std::chrono::steady_clock::time_point now() {
+        return std::chrono::steady_clock::now();
+    }
+
+    inline int64_t elapsed_ms(std::chrono::steady_clock::time_point start) {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(now() - start).count();
+    }
+
+    bool luid_in_range(int64_t luid, const int64_t *luid_range, int32_t luid_range_count);
+}
+
 
 #endif

--- a/cpp/ffmpeg_ram/ffmpeg_ram_decode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_decode.cpp
@@ -13,7 +13,7 @@ extern "C" {
 
 #define LOG_MODULE "FFMPEG_RAM_DEC"
 #include <log.h>
-#include <uitl.h>
+#include <util.h>
 
 #ifdef _WIN32
 #include <libavutil/hwcontext_d3d11va.h>

--- a/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
@@ -14,7 +14,7 @@ extern "C" {
 
 #define LOG_MODULE "FFMPEG_RAM_ENC"
 #include <log.h>
-#include <uitl.h>
+#include <util.h>
 #ifdef _WIN32
 #include "win.h"
 #endif

--- a/cpp/ffmpeg_vram/ffmpeg_vram_decode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_decode.cpp
@@ -19,7 +19,7 @@ extern "C" {
 
 #define LOG_MODULE "FFMPEG_VRAM_DEC"
 #include <log.h>
-#include <uitl.h>
+#include <util.h>
 
 namespace {
 
@@ -359,8 +359,8 @@ extern "C" int ffmpeg_vram_decode(FFmpegVRamDecoder *decoder,
   return HWCODEC_ERR_COMMON;
 }
 
-extern "C" int ffmpeg_vram_test_decode(AdapterDesc *outDescs,
-                                       int32_t maxDescNum, int32_t *outDescNum,
+extern "C" int ffmpeg_vram_test_decode(AdapterDesc *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                                       const int64_t *luid_range, int32_t luid_range_count,
                                        API api, DataFormat dataFormat,
                                        uint8_t *data, int32_t length) {
   try {
@@ -368,25 +368,45 @@ extern "C" int ffmpeg_vram_test_decode(AdapterDesc *outDescs,
     int count = 0;
     AdapterVendor vendors[] = {ADAPTER_VENDOR_INTEL, ADAPTER_VENDOR_NVIDIA,
                                ADAPTER_VENDOR_AMD};
+    #include "../nv/nv_ffi.h"
+    #include "../amf/amf_ffi.h"
+    bool support_nv  = nv_decode_driver_support() == 0;
+    bool support_amf = amf_driver_support() == 0;
     for (auto vendor : vendors) {
       Adapters adapters;
       if (!adapters.Init(vendor))
         continue;
       for (auto &adapter : adapters.adapters_) {
+        int64_t luid = LUID(adapter.get()->desc1_);
+        if (vendor == ADAPTER_VENDOR_NVIDIA) {
+          // nv sdk decode is disabled, so nv only check driver support
+          if (!support_nv)
+            continue;
+        } else if (vendor == ADAPTER_VENDOR_AMD && dataFormat == H265) {
+          // amf sdk h265 is disabled, so amf h265 only check driver support
+          if (!support_amf)
+            continue;
+        } else {
+          if (!util::luid_in_range(luid, luid_range, luid_range_count))
+            continue;
+        }
         FFmpegVRamDecoder *p = (FFmpegVRamDecoder *)ffmpeg_vram_new_decoder(
-            nullptr, LUID(adapter.get()->desc1_), api, dataFormat);
+            nullptr, luid, api, dataFormat);
         if (!p)
           continue;
-        if (ffmpeg_vram_decode(p, data, length, nullptr, nullptr) == 0) {
+        auto start = util::now();
+        bool succ = ffmpeg_vram_decode(p, data, length, nullptr, nullptr) == 0;
+        int64_t elapsed = util::elapsed_ms(start);
+        if (succ && elapsed < TEST_TIMEOUT_MS) {
           AdapterDesc *desc = descs + count;
-          desc->luid = LUID(adapter.get()->desc1_);
+          desc->luid = luid;
           count += 1;
-          p->destroy();
-          delete p;
-          p = nullptr;
-          if (count >= maxDescNum)
-            break;
         }
+        p->destroy();
+        delete p;
+        p = nullptr;
+        if (count >= maxDescNum)
+          break;
       }
       if (count >= maxDescNum)
         break;

--- a/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
@@ -22,7 +22,7 @@ extern "C" {
 
 #define LOG_MODULE "FFMPEG_VRAM_ENC"
 #include <log.h>
-#include <uitl.h>
+#include <util.h>
 
 namespace {
 
@@ -494,8 +494,9 @@ int ffmpeg_vram_set_framerate(FFmpegVRamEncoder *encoder, int32_t framerate) {
   return -1;
 }
 
-int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum,
-                            int32_t *outDescNum, API api, DataFormat dataFormat,
+int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum, 
+                            const int64_t *luid_range, int32_t luid_range_count,
+                            API api, DataFormat dataFormat,
                             int32_t width, int32_t height, int32_t kbs,
                             int32_t framerate, int32_t gop) {
   try {
@@ -508,18 +509,24 @@ int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum,
       if (!adapters.Init(vendor))
         continue;
       for (auto &adapter : adapters.adapters_) {
+        int64_t luid = LUID(adapter.get()->desc1_);
+        if (!util::luid_in_range(luid, luid_range, luid_range_count))
+          continue;
         FFmpegVRamEncoder *e = (FFmpegVRamEncoder *)ffmpeg_vram_new_encoder(
-            (void *)adapter.get()->device_.Get(), LUID(adapter.get()->desc1_),
+            (void *)adapter.get()->device_.Get(), luid,
             api, dataFormat, width, height, kbs, framerate, gop);
         if (!e)
           continue;
         if (e->native_->EnsureTexture(e->width_, e->height_)) {
           e->native_->next();
           int32_t key_obj = 0;
-          if (ffmpeg_vram_encode(e, e->native_->GetCurrentTexture(), util_encode::vram_encode_test_callback,
-                                 &key_obj, 0) == 0 && key_obj == 1) {
+          auto start = util::now();
+          bool succ = ffmpeg_vram_encode(e, e->native_->GetCurrentTexture(), util_encode::vram_encode_test_callback,
+                                 &key_obj, 0) == 0 && key_obj == 1;
+          int64_t elapsed = util::elapsed_ms(start);
+          if (succ && elapsed < TEST_TIMEOUT_MS) {
             AdapterDesc *desc = descs + count;
-            desc->luid = LUID(adapter.get()->desc1_);
+            desc->luid = luid;
             count += 1;
           }
         }

--- a/cpp/ffmpeg_vram/ffmpeg_vram_ffi.h
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_ffi.h
@@ -9,9 +9,9 @@ void *ffmpeg_vram_new_decoder(void *device, int64_t luid, int32_t api,
 int ffmpeg_vram_decode(void *decoder, uint8_t *data, int len,
                        DecodeCallback callback, void *obj);
 int ffmpeg_vram_destroy_decoder(void *decoder);
-int ffmpeg_vram_test_decode(void *outDescs, int32_t maxDescNum,
-                            int32_t *outDescNum, int32_t api,
-                            int32_t dataFormat, uint8_t *data, int32_t length);
+int ffmpeg_vram_test_decode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                            const int64_t *luid_range, int32_t luid_range_count,
+                            int32_t api, int32_t dataFormat, uint8_t *data, int32_t length);
 void *ffmpeg_vram_new_encoder(void *handle, int64_t luid, int32_t api,
                               int32_t dataFormat, int32_t width, int32_t height,
                               int32_t kbs, int32_t framerate, int32_t gop);
@@ -20,8 +20,9 @@ int ffmpeg_vram_encode(void *encoder, void *tex, EncodeCallback callback,
                        void *obj, int64_t ms);
 int ffmpeg_vram_destroy_encoder(void *encoder);
 
-int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum,
-                            int32_t *outDescNum, int32_t api,
+int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                            const int64_t *luid_range, int32_t luid_range_count,
+                            int32_t api,
                             int32_t dataFormat, int32_t width, int32_t height,
                             int32_t kbs, int32_t framerate, int32_t gop);
 int ffmpeg_vram_set_bitrate(void *encoder, int32_t kbs);

--- a/cpp/mfx/mfx_encode.cpp
+++ b/cpp/mfx/mfx_encode.cpp
@@ -8,7 +8,7 @@
 #include "callback.h"
 #include "common.h"
 #include "system.h"
-#include "uitl.h"
+#include "util.h"
 
 #define LOG_MODULE "MFXENC"
 #include "log.h"
@@ -609,6 +609,7 @@ int mfx_encode(void *encoder, ID3D11Texture2D *tex, EncodeCallback callback,
 }
 
 int mfx_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                    const int64_t *luid_range, int32_t luid_range_count,
                     API api, DataFormat dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
                     int32_t gop) {
@@ -627,8 +628,11 @@ int mfx_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
       if (e->native_->EnsureTexture(e->width_, e->height_)) {
         e->native_->next();
         int32_t key_obj = 0;
-        if (mfx_encode(e, e->native_->GetCurrentTexture(), util_encode::vram_encode_test_callback, &key_obj,
-                       0) == 0 && key_obj == 1) {
+        auto start = util::now();
+        bool succ = mfx_encode(e, e->native_->GetCurrentTexture(), util_encode::vram_encode_test_callback, &key_obj,
+                       0) == 0 && key_obj == 1;
+        int64_t elapsed = util::elapsed_ms(start);
+        if (succ && elapsed < TEST_TIMEOUT_MS) {
           AdapterDesc *desc = descs + count;
           desc->luid = LUID(adapter.get()->desc1_);
           count += 1;

--- a/cpp/mfx/mfx_ffi.h
+++ b/cpp/mfx/mfx_ffi.h
@@ -24,11 +24,13 @@ int mfx_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
 int mfx_destroy_decoder(void *decoder);
 
 int mfx_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                    const int64_t *luid_range, int32_t luid_range_count,
                     int32_t api, int32_t dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
                     int32_t gop);
 
 int mfx_test_decode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                    const int64_t *luid_range, int32_t luid_range_count,
                     int32_t api, int32_t dataFormat, uint8_t *data,
                     int32_t length);
 

--- a/cpp/nv/nv_decode.cpp
+++ b/cpp/nv/nv_decode.cpp
@@ -15,6 +15,7 @@
 #include "callback.h"
 #include "common.h"
 #include "system.h"
+#include "util.h"
 
 #define LOG_MODULE "CUVID"
 #include "log.h"
@@ -652,9 +653,9 @@ int nv_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
   return HWCODEC_ERR_COMMON;
 }
 
-int nv_test_decode(AdapterDesc *outDescs, int32_t maxDescNum,
-                   int32_t *outDescNum, API api, DataFormat dataFormat,
-                   uint8_t *data, int32_t length) {
+int nv_test_decode(AdapterDesc *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                   const int64_t *luid_range, int32_t luid_range_count,
+                   API api, DataFormat dataFormat, uint8_t *data, int32_t length) {
   try {
     AdapterDesc *descs = (AdapterDesc *)outDescs;
     Adapters adapters;
@@ -666,16 +667,19 @@ int nv_test_decode(AdapterDesc *outDescs, int32_t maxDescNum,
           nullptr, LUID(adapter.get()->desc1_), api, dataFormat);
       if (!p)
         continue;
-      if (nv_decode(p, data, length, nullptr, nullptr) == 0) {
+      auto start = util::now();
+      bool succ = nv_decode(p, data, length, nullptr, nullptr) == 0;
+      int64_t elapsed = util::elapsed_ms(start);
+      if (succ && elapsed < TEST_TIMEOUT_MS) {
         AdapterDesc *desc = descs + count;
         desc->luid = LUID(adapter.get()->desc1_);
         count += 1;
-        p->destroy();
-        delete p;
-        p = nullptr;
-        if (count >= maxDescNum)
-          break;
       }
+      p->destroy();
+      delete p;
+      p = nullptr;
+      if (count >= maxDescNum)
+        break;
     }
     *outDescNum = count;
     return 0;

--- a/cpp/nv/nv_encode.cpp
+++ b/cpp/nv/nv_encode.cpp
@@ -22,7 +22,7 @@ using Microsoft::WRL::ComPtr;
 #include "callback.h"
 #include "common.h"
 #include "system.h"
-#include "uitl.h"
+#include "util.h"
 
 #define LOG_MODULE "NVENC"
 #include "log.h"
@@ -393,6 +393,7 @@ int nv_encode(void *encoder, void *texture, EncodeCallback callback, void *obj,
   }
 
 int nv_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                   const int64_t *luid_range, int32_t luid_range_count,
                    API api, DataFormat dataFormat, int32_t width,
                    int32_t height, int32_t kbs, int32_t framerate,
                    int32_t gop) {
@@ -411,8 +412,11 @@ int nv_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
       if (e->native_->EnsureTexture(e->width_, e->height_)) {
         e->native_->next();
         int32_t key_obj = 0;
-        if (nv_encode(e, e->native_->GetCurrentTexture(), util_encode::vram_encode_test_callback, &key_obj,
-                      0) == 0 && key_obj == 1) {
+        auto start = util::now();
+        bool succ = nv_encode(e, e->native_->GetCurrentTexture(), util_encode::vram_encode_test_callback, &key_obj,
+                      0) == 0 && key_obj == 1;
+        int64_t elapsed = util::elapsed_ms(start);
+        if (succ && elapsed < TEST_TIMEOUT_MS) {
           AdapterDesc *desc = descs + count;
           desc->luid = LUID(adapter.get()->desc1_);
           count += 1;

--- a/cpp/nv/nv_ffi.h
+++ b/cpp/nv/nv_ffi.h
@@ -25,10 +25,12 @@ int nv_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
 int nv_destroy_decoder(void *decoder);
 
 int nv_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                   const int64_t *luid_range, int32_t luid_range_count,
                    int32_t api, int32_t dataFormat, int32_t width,
                    int32_t height, int32_t kbs, int32_t framerate, int32_t gop);
 
 int nv_test_decode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
+                   const int64_t *luid_range, int32_t luid_range_count,
                    int32_t api, int32_t dataFormat, uint8_t *data,
                    int32_t length);
 

--- a/src/ffmpeg_ram/encode.rs
+++ b/src/ffmpeg_ram/encode.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{
         DataFormat::{self, *},
-        Quality, RateControl,
+        Quality, RateControl, TEST_TIMEOUT_MS,
     },
     ffmpeg::{init_av_log, AVPixelFormat},
     ffmpeg_ram::{
@@ -326,9 +326,12 @@ impl Encoder {
                         ..ctx
                     };
                     if let Ok(mut encoder) = Encoder::new(c) {
+                        let start = std::time::Instant::now();
                         if let Ok(frames) = encoder.encode(&yuv, 0) {
                             if frames.len() == 1 {
-                                if frames[0].key == 1 {
+                                if frames[0].key == 1
+                                    && start.elapsed().as_millis() < TEST_TIMEOUT_MS as _
+                                {
                                     infos.lock().unwrap().push(codec);
                                 }
                             }

--- a/src/vram/inner.rs
+++ b/src/vram/inner.rs
@@ -36,6 +36,8 @@ pub type TestEncodeCall = unsafe extern "C" fn(
     outDescs: *mut c_void,
     maxDescNum: i32,
     outDescNum: *mut i32,
+    luid_range: *const i64,
+    luid_range_count: i32,
     api: i32,
     dataFormat: i32,
     width: i32,
@@ -49,6 +51,8 @@ pub type TestDecodeCall = unsafe extern "C" fn(
     outDescs: *mut c_void,
     maxDescNum: i32,
     outDescNum: *mut i32,
+    luid_range: *const i64,
+    luid_range_count: i32,
     api: i32,
     dataFormat: i32,
     data: *mut u8,
@@ -74,11 +78,13 @@ pub struct DecodeCalls {
     pub test: TestDecodeCall,
 }
 
+#[derive(Clone)]
 pub struct InnerEncodeContext {
     pub api: API,
     pub format: DataFormat,
 }
 
+#[derive(Clone)]
 pub struct InnerDecodeContext {
     pub api: API,
     pub data_format: DataFormat,


### PR DESCRIPTION
1. Each adapter has a unique luid. When checking for H.264 or H.265, pass the adapter luid array retrieved from the SDK test results to FFmpeg, FFmpeg can only use luids from this array.
2. Add a 300ms timeout for all encoding and decoding checks.
3. Fix the VRAM decode memory leak during test by ensuring the decoder is always destroyed.

Intel/Nvidia PC: original result:
  
![original](https://github.com/user-attachments/assets/b9cfa692-8ab0-4feb-a691-375daeed68d6)

Intel/Nvidia PC: let nv sdk encode and mfx sdk decode timeout

![nv-sdk-encode-mfx-sdk-decode-sleep-100ms](https://github.com/user-attachments/assets/063415ef-3188-463c-ae95-d8bd1a8d94a9)

AMD PC: original result:

![original](https://github.com/user-attachments/assets/7e6633d5-8dcb-4c60-a8ab-3a621626df6a)

AMD PC:  let ffmpeg encode and amf decode timeout

![ffmpeg_vram_encode_amf_sdk_decode_sleep_100ms](https://github.com/user-attachments/assets/16dae9af-fd0b-4cd4-9171-168f059e97c5)


I'll check the amd sdk decode memory leak warning later, the warning is six textures if rustdesk uses the decoder.
