### PR TITLE
add more encode/decode timeout

### DIFF
--- a/cpp/amf/amf_decode.cpp
+++ b/cpp/amf/amf_decode.cpp
@@ -403,7 +403,6 @@ int amf_decode(void *decoder, uint8_t *data, int32_t length,
 }
 
 int amf_test_decode(AdapterDesc *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                    const int64_t *luid_range, int32_t luid_range_count,
                     API api, DataFormat dataFormat, uint8_t *data, int32_t length) {
   try {
     AdapterDesc *descs = (AdapterDesc *)outDescs;

--- a/cpp/amf/amf_decode.cpp
+++ b/cpp/amf/amf_decode.cpp
@@ -88,12 +88,7 @@ public:
     }
     AMF_CHECK_RETURN(res, "SubmitInput failed");
     amf::AMFDataPtr oData = NULL;
-    do {
-      res = AMFDecoder_->QueryOutput(&oData);
-      if (res == AMF_REPEAT) {
-        amf_sleep(1);
-      }
-    } while (res == AMF_REPEAT);
+    res = AMFDecoder_->QueryOutput(&oData);
     if (res == AMF_OK && oData != NULL) {
       amf::AMFSurfacePtr surface(oData);
       AMF_RETURN_IF_INVALID_POINTER(surface, L"surface is NULL");

--- a/cpp/amf/amf_encode.cpp
+++ b/cpp/amf/amf_encode.cpp
@@ -129,13 +129,7 @@ public:
     AMF_CHECK_RETURN(res, "SubmitInput failed");
 
     amf::AMFDataPtr data = NULL;
-    do {
-      data = NULL;
-      res = AMFEncoder_->QueryOutput(&data);
-      if (res == AMF_REPEAT) {
-        amf_sleep(1);
-      }
-    } while (res == AMF_REPEAT);
+    res = AMFEncoder_->QueryOutput(&data);
     if (res == AMF_OK && data != NULL) {
       struct encoder_packet packet;
       PacketKeyframe(data, &packet);

--- a/cpp/amf/amf_ffi.h
+++ b/cpp/amf/amf_ffi.h
@@ -30,7 +30,6 @@ int amf_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
                     int32_t gop);
 
 int amf_test_decode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                    const int64_t *luid_range, int32_t luid_range_count,
                     int32_t api, int32_t dataFormat, uint8_t *data,
                     int32_t length);
 

--- a/cpp/common/common.h
+++ b/cpp/common/common.h
@@ -6,6 +6,8 @@
 #define MAX_GOP 0x7FFFFFFF // i32 max
 
 #define TEST_TIMEOUT_MS 300
+#define ENCODE_TIMEOUT_MS 1000
+#define DECODE_TIMEOUT_MS 1000
 
 enum AdapterVendor {
   ADAPTER_VENDOR_AMD = 0x1002,

--- a/cpp/ffmpeg_ram/ffmpeg_ram_decode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_decode.cpp
@@ -183,8 +183,8 @@ private:
       LOG_ERROR("avcodec_send_packet failed, ret = " + av_err2str(ret));
       return ret;
     }
-
-    while (ret >= 0) {
+    auto start = util::now();
+    while (ret >= 0 && util::elapsed_ms(start) < ENCODE_TIMEOUT_MS) {
       if ((ret = avcodec_receive_frame(c_, frame_)) != 0) {
         if (ret != AVERROR(EAGAIN)) {
           LOG_ERROR("avcodec_receive_frame failed, ret = " + av_err2str(ret));

--- a/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
@@ -343,7 +343,8 @@ private:
       return ret;
     }
 
-    while (ret >= 0) {
+    auto start = util::now();
+    while (ret >= 0 && util::elapsed_ms(start) < DECODE_TIMEOUT_MS) {
       if ((ret = avcodec_receive_packet(c_, pkt_)) < 0) {
         if (ret != AVERROR(EAGAIN)) {
           LOG_ERROR("avcodec_receive_packet failed, ret = " + av_err2str(ret));

--- a/cpp/ffmpeg_vram/ffmpeg_vram_decode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_decode.cpp
@@ -193,7 +193,8 @@ private:
       return ret;
     }
 
-    while (ret >= 0) {
+    auto start = util::now();
+    while (ret >= 0 && util::elapsed_ms(start) < DECODE_TIMEOUT_MS) {
       if ((ret = avcodec_receive_frame(c_, frame_)) != 0) {
         if (ret != AVERROR(EAGAIN)) {
           LOG_ERROR("avcodec_receive_frame failed, ret = " + av_err2str(ret));

--- a/cpp/ffmpeg_vram/ffmpeg_vram_decode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_decode.cpp
@@ -361,7 +361,6 @@ extern "C" int ffmpeg_vram_decode(FFmpegVRamDecoder *decoder,
 }
 
 extern "C" int ffmpeg_vram_test_decode(AdapterDesc *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                                       const int64_t *luid_range, int32_t luid_range_count,
                                        API api, DataFormat dataFormat,
                                        uint8_t *data, int32_t length) {
   try {
@@ -369,28 +368,12 @@ extern "C" int ffmpeg_vram_test_decode(AdapterDesc *outDescs, int32_t maxDescNum
     int count = 0;
     AdapterVendor vendors[] = {ADAPTER_VENDOR_INTEL, ADAPTER_VENDOR_NVIDIA,
                                ADAPTER_VENDOR_AMD};
-    #include "../nv/nv_ffi.h"
-    #include "../amf/amf_ffi.h"
-    bool support_nv  = nv_decode_driver_support() == 0;
-    bool support_amf = amf_driver_support() == 0;
     for (auto vendor : vendors) {
       Adapters adapters;
       if (!adapters.Init(vendor))
         continue;
       for (auto &adapter : adapters.adapters_) {
         int64_t luid = LUID(adapter.get()->desc1_);
-        if (vendor == ADAPTER_VENDOR_NVIDIA) {
-          // nv sdk decode is disabled, so nv only check driver support
-          if (!support_nv)
-            continue;
-        } else if (vendor == ADAPTER_VENDOR_AMD && dataFormat == H265) {
-          // amf sdk h265 is disabled, so amf h265 only check driver support
-          if (!support_amf)
-            continue;
-        } else {
-          if (!util::luid_in_range(luid, luid_range, luid_range_count))
-            continue;
-        }
         FFmpegVRamDecoder *p = (FFmpegVRamDecoder *)ffmpeg_vram_new_decoder(
             nullptr, luid, api, dataFormat);
         if (!p)

--- a/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
@@ -322,7 +322,8 @@ private:
       return ret;
     }
 
-    while (ret >= 0) {
+    auto start = util::now();
+    while (ret >= 0 && util::elapsed_ms(start) < ENCODE_TIMEOUT_MS) {
       if ((ret = avcodec_receive_packet(c_, pkt_)) < 0) {
         if (ret != AVERROR(EAGAIN)) {
           LOG_ERROR("avcodec_receive_packet failed, ret = " + av_err2str(ret));

--- a/cpp/ffmpeg_vram/ffmpeg_vram_ffi.h
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_ffi.h
@@ -10,7 +10,6 @@ int ffmpeg_vram_decode(void *decoder, uint8_t *data, int len,
                        DecodeCallback callback, void *obj);
 int ffmpeg_vram_destroy_decoder(void *decoder);
 int ffmpeg_vram_test_decode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                            const int64_t *luid_range, int32_t luid_range_count,
                             int32_t api, int32_t dataFormat, uint8_t *data, int32_t length);
 void *ffmpeg_vram_new_encoder(void *handle, int64_t luid, int32_t api,
                               int32_t dataFormat, int32_t width, int32_t height,

--- a/cpp/mfx/mfx_decode.cpp
+++ b/cpp/mfx/mfx_decode.cpp
@@ -131,10 +131,10 @@ public:
     }
     setBitStream(&mfxBS, data, len);
 
-    int loop_counter = 0;
+    auto start = util::now();
     do {
-      if (loop_counter++ > 100) {
-        LOG_ERROR("mfx decode loop two many times");
+      if (util::elapsed_ms(start) > DECODE_TIMEOUT_MS) {
+        LOG_ERROR("decode timeout");
         break;
       }
       int nIndex =

--- a/cpp/mfx/mfx_decode.cpp
+++ b/cpp/mfx/mfx_decode.cpp
@@ -442,7 +442,6 @@ int mfx_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
 }
 
 int mfx_test_decode(AdapterDesc *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                    const int64_t *luid_range, int32_t luid_range_count,
                     API api, DataFormat dataFormat, uint8_t *data, int32_t length) {
   try {
     AdapterDesc *descs = (AdapterDesc *)outDescs;

--- a/cpp/mfx/mfx_encode.cpp
+++ b/cpp/mfx/mfx_encode.cpp
@@ -456,10 +456,10 @@ private:
     mfxSyncPoint syncp;
     bool encoded = false;
 
-    int loop_counter = 0;
+    auto start = util::now();
     do {
-      if (loop_counter++ > 100) {
-        LOG_ERROR("mfx encode loop two many times");
+      if (util::elapsed_ms(start) > ENCODE_TIMEOUT_MS) {
+        LOG_ERROR("encode timeout");
         break;
       }
       mfxBS_.DataLength = 0;

--- a/cpp/mfx/mfx_ffi.h
+++ b/cpp/mfx/mfx_ffi.h
@@ -30,7 +30,6 @@ int mfx_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
                     int32_t gop);
 
 int mfx_test_decode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                    const int64_t *luid_range, int32_t luid_range_count,
                     int32_t api, int32_t dataFormat, uint8_t *data,
                     int32_t length);
 

--- a/cpp/nv/nv_decode.cpp
+++ b/cpp/nv/nv_decode.cpp
@@ -654,7 +654,6 @@ int nv_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
 }
 
 int nv_test_decode(AdapterDesc *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                   const int64_t *luid_range, int32_t luid_range_count,
                    API api, DataFormat dataFormat, uint8_t *data, int32_t length) {
   try {
     AdapterDesc *descs = (AdapterDesc *)outDescs;

--- a/cpp/nv/nv_ffi.h
+++ b/cpp/nv/nv_ffi.h
@@ -30,7 +30,6 @@ int nv_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
                    int32_t height, int32_t kbs, int32_t framerate, int32_t gop);
 
 int nv_test_decode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                   const int64_t *luid_range, int32_t luid_range_count,
                    int32_t api, int32_t dataFormat, uint8_t *data,
                    int32_t length);
 

--- a/examples/available.rs
+++ b/examples/available.rs
@@ -37,7 +37,7 @@ fn ram() {
     let encoders = Encoder::available_encoders(ctx.clone(), None);
     encoders.iter().map(|e| println!("{:?}", e)).count();
     println!("decoders:");
-    let decoders = Decoder::available_decoders(None);
+    let decoders = Decoder::available_decoders();
     decoders.iter().map(|e| println!("{:?}", e)).count();
 }
 

--- a/src/ffmpeg_ram/decode.rs
+++ b/src/ffmpeg_ram/decode.rs
@@ -161,43 +161,26 @@ impl Decoder {
         }
     }
 
-    pub fn available_decoders(sdk: Option<String>) -> Vec<CodecInfo> {
+    pub fn available_decoders() -> Vec<CodecInfo> {
         use std::{mem::MaybeUninit, sync::Once};
 
         static mut INSTANCE: MaybeUninit<Vec<CodecInfo>> = MaybeUninit::uninit();
         static ONCE: Once = Once::new();
 
         ONCE.call_once(|| unsafe {
-            INSTANCE
-                .as_mut_ptr()
-                .write(Decoder::available_decoders_(sdk));
+            INSTANCE.as_mut_ptr().write(Decoder::available_decoders_());
         });
         unsafe { (&*INSTANCE.as_ptr()).clone() }
     }
 
-    fn available_decoders_(_sdk: Option<String>) -> Vec<CodecInfo> {
+    fn available_decoders_() -> Vec<CodecInfo> {
         #[allow(unused_mut)]
         let mut codecs: Vec<CodecInfo> = vec![];
         // windows disable nvdec to avoid gpu stuck
         #[cfg(target_os = "linux")]
         {
             let (nv, _, _) = crate::common::supported_gpu(false);
-            let contains = |_driver: Driver, _format: DataFormat| {
-                #[cfg(all(windows, feature = "vram"))]
-                {
-                    if let Some(_sdk) = _sdk.as_ref() {
-                        if !_sdk.is_empty() {
-                            if let Ok(available) =
-                                crate::vram::Available::deserialize(_sdk.as_str())
-                            {
-                                return available.contains(false, _driver, _format);
-                            }
-                        }
-                    }
-                }
-                true
-            };
-            if nv && contains(Driver::NV, H264) {
+            if nv {
                 codecs.push(CodecInfo {
                     name: "h264".to_owned(),
                     format: H264,
@@ -205,8 +188,6 @@ impl Decoder {
                     priority: Priority::Good as _,
                     ..Default::default()
                 });
-            }
-            if nv && contains(Driver::NV, H265) {
                 codecs.push(CodecInfo {
                     name: "hevc".to_owned(),
                     format: H265,

--- a/src/vram/decode.rs
+++ b/src/vram/decode.rs
@@ -121,6 +121,12 @@ pub fn available() -> Vec<DecodeContext> {
     //         .collect(),
     // );
     codecs.append(
+        &mut ffmpeg::possible_support_decoders()
+            .drain(..)
+            .map(|n| (FFMPEG, n))
+            .collect(),
+    );
+    codecs.append(
         &mut amf::possible_support_decoders()
             .drain(..)
             .map(|n| (AMF, n))
@@ -132,27 +138,10 @@ pub fn available() -> Vec<DecodeContext> {
             .map(|n| (MFX, n))
             .collect(),
     );
-    let mut result = do_test(codecs, vec![]);
-    let ffmpeg_possible_support_decoders = ffmpeg::possible_support_decoders();
-    for format in [H264, H265] {
-        let luids: Vec<_> = result
-            .iter()
-            .filter(|e| e.data_format == format)
-            .map(|e| e.luid)
-            .collect();
-        let v: Vec<_> = ffmpeg_possible_support_decoders
-            .clone()
-            .drain(..)
-            .filter(|e| e.data_format == format)
-            .map(|n| (FFMPEG, n))
-            .collect();
-        let mut v = do_test(v, luids);
-        result.append(&mut v);
-    }
-    result
+    do_test(codecs)
 }
 
-fn do_test(codecs: Vec<(Driver, InnerDecodeContext)>, luid_range: Vec<i64>) -> Vec<DecodeContext> {
+fn do_test(codecs: Vec<(Driver, InnerDecodeContext)>) -> Vec<DecodeContext> {
     let mut codecs = codecs;
     let inputs = codecs.drain(..).map(|(driver, n)| DecodeContext {
         device: None,
@@ -171,7 +160,6 @@ fn do_test(codecs: Vec<(Driver, InnerDecodeContext)>, luid_range: Vec<i64>) -> V
         let buf264 = buf264.clone();
         let buf265 = buf265.clone();
         let mutex = mutex.clone();
-        let luid_range = luid_range.clone();
         let handle = thread::spawn(move || {
             let _lock;
             if input.driver == NV || input.driver == FFMPEG {
@@ -196,8 +184,6 @@ fn do_test(codecs: Vec<(Driver, InnerDecodeContext)>, luid_range: Vec<i64>) -> V
                     descs.as_mut_ptr() as _,
                     descs.len() as _,
                     &mut desc_count,
-                    luid_range.as_ptr(),
-                    luid_range.len() as _,
                     input.api as _,
                     input.data_format as i32,
                     data.as_ptr() as *mut u8,

--- a/src/vram/inner.rs
+++ b/src/vram/inner.rs
@@ -51,8 +51,6 @@ pub type TestDecodeCall = unsafe extern "C" fn(
     outDescs: *mut c_void,
     maxDescNum: i32,
     outDescNum: *mut i32,
-    luid_range: *const i64,
-    luid_range_count: i32,
     api: i32,
     dataFormat: i32,
     data: *mut u8,


### PR DESCRIPTION
1. add more encode/decode timeout
2. Fix amf decode memory leak warning.
3. Remove filter FFmpeg vram decode luid because it's using d3d11, not the same codec.

before:
![image](https://github.com/user-attachments/assets/433a4f44-6829-41e0-93f5-1793da8d5a46)

after:
![image](https://github.com/user-attachments/assets/d5ee94b4-c044-4dfb-8886-255c20a0f049)
