### PR TITLE
remove using sdk result to filter FFmpeg vram encode

### DIFF
--- a/cpp/amf/amf_encode.cpp
+++ b/cpp/amf/amf_encode.cpp
@@ -525,7 +525,6 @@ int amf_driver_support() {
 }
 
 int amf_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                    const int64_t *luid_range, int32_t luid_range_count,
                     API api, DataFormat dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
                     int32_t gop) {

--- a/cpp/amf/amf_ffi.h
+++ b/cpp/amf/amf_ffi.h
@@ -24,7 +24,6 @@ int amf_decode(void *decoder, uint8_t *data, int32_t length,
 int amf_destroy_decoder(void *decoder);
 
 int amf_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                    const int64_t *luid_range, int32_t luid_range_count,
                     int32_t api, int32_t dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
                     int32_t gop);

--- a/cpp/common/common.h
+++ b/cpp/common/common.h
@@ -5,7 +5,7 @@
 
 #define MAX_GOP 0x7FFFFFFF // i32 max
 
-#define TEST_TIMEOUT_MS 300
+#define TEST_TIMEOUT_MS 1000
 #define ENCODE_TIMEOUT_MS 1000
 #define DECODE_TIMEOUT_MS 1000
 

--- a/cpp/common/util.cpp
+++ b/cpp/common/util.cpp
@@ -328,15 +328,4 @@ extern "C" void hwcodec_set_flag_could_not_find_ref_with_poc() {
   util_decode::g_flag_could_not_find_ref_with_poc = true;
 }
 
-namespace util {
-bool luid_in_range(int64_t luid, const int64_t *luid_range, int32_t luid_range_count) {
-  if (!luid_range || luid_range_count == 0)
-    return false;
-  for (int i = 0; i < luid_range_count; i++) {
-    if (luid == luid_range[i]) {
-      return true;
-    }
-  }
-  return false;
-}
-}
+

--- a/cpp/common/util.h
+++ b/cpp/common/util.h
@@ -37,8 +37,6 @@ namespace util {
     inline int64_t elapsed_ms(std::chrono::steady_clock::time_point start) {
         return std::chrono::duration_cast<std::chrono::milliseconds>(now() - start).count();
     }
-
-    bool luid_in_range(int64_t luid, const int64_t *luid_range, int32_t luid_range_count);
 }
 
 

--- a/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
@@ -496,7 +496,6 @@ int ffmpeg_vram_set_framerate(FFmpegVRamEncoder *encoder, int32_t framerate) {
 }
 
 int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum, 
-                            const int64_t *luid_range, int32_t luid_range_count,
                             API api, DataFormat dataFormat,
                             int32_t width, int32_t height, int32_t kbs,
                             int32_t framerate, int32_t gop) {
@@ -511,8 +510,6 @@ int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDesc
         continue;
       for (auto &adapter : adapters.adapters_) {
         int64_t luid = LUID(adapter.get()->desc1_);
-        if (!util::luid_in_range(luid, luid_range, luid_range_count))
-          continue;
         FFmpegVRamEncoder *e = (FFmpegVRamEncoder *)ffmpeg_vram_new_encoder(
             (void *)adapter.get()->device_.Get(), luid,
             api, dataFormat, width, height, kbs, framerate, gop);

--- a/cpp/ffmpeg_vram/ffmpeg_vram_ffi.h
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_ffi.h
@@ -20,7 +20,6 @@ int ffmpeg_vram_encode(void *encoder, void *tex, EncodeCallback callback,
 int ffmpeg_vram_destroy_encoder(void *encoder);
 
 int ffmpeg_vram_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                            const int64_t *luid_range, int32_t luid_range_count,
                             int32_t api,
                             int32_t dataFormat, int32_t width, int32_t height,
                             int32_t kbs, int32_t framerate, int32_t gop);

--- a/cpp/mfx/mfx_encode.cpp
+++ b/cpp/mfx/mfx_encode.cpp
@@ -609,7 +609,6 @@ int mfx_encode(void *encoder, ID3D11Texture2D *tex, EncodeCallback callback,
 }
 
 int mfx_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                    const int64_t *luid_range, int32_t luid_range_count,
                     API api, DataFormat dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
                     int32_t gop) {

--- a/cpp/mfx/mfx_ffi.h
+++ b/cpp/mfx/mfx_ffi.h
@@ -24,7 +24,6 @@ int mfx_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
 int mfx_destroy_decoder(void *decoder);
 
 int mfx_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                    const int64_t *luid_range, int32_t luid_range_count,
                     int32_t api, int32_t dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
                     int32_t gop);

--- a/cpp/nv/nv_encode.cpp
+++ b/cpp/nv/nv_encode.cpp
@@ -392,7 +392,6 @@ int nv_encode(void *encoder, void *texture, EncodeCallback callback, void *obj,
   }
 
 int nv_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                   const int64_t *luid_range, int32_t luid_range_count,
                    API api, DataFormat dataFormat, int32_t width,
                    int32_t height, int32_t kbs, int32_t framerate,
                    int32_t gop) {

--- a/cpp/nv/nv_ffi.h
+++ b/cpp/nv/nv_ffi.h
@@ -25,7 +25,6 @@ int nv_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
 int nv_destroy_decoder(void *decoder);
 
 int nv_test_encode(void *outDescs, int32_t maxDescNum, int32_t *outDescNum,
-                   const int64_t *luid_range, int32_t luid_range_count,
                    int32_t api, int32_t dataFormat, int32_t width,
                    int32_t height, int32_t kbs, int32_t framerate, int32_t gop);
 

--- a/src/vram/inner.rs
+++ b/src/vram/inner.rs
@@ -36,8 +36,6 @@ pub type TestEncodeCall = unsafe extern "C" fn(
     outDescs: *mut c_void,
     maxDescNum: i32,
     outDescNum: *mut i32,
-    luid_range: *const i64,
-    luid_range_count: i32,
     api: i32,
     dataFormat: i32,
     width: i32,


### PR DESCRIPTION
![amd](https://github.com/user-attachments/assets/5bde6675-3292-4f92-bf8d-1d68d4851bef)

![image](https://github.com/user-attachments/assets/19a4d342-a535-44eb-b691-70a2ecde482a)
