### PR TITLE
Fix image blur occurring at the moment of changing quality with FFmpeg QSV and SDK MFX codecs.

### DIFF
--- a/cpp/common/util.cpp
+++ b/cpp/common/util.cpp
@@ -204,6 +204,10 @@ struct CodecOptions {
 
 bool set_rate_control(AVCodecContext *c, const std::string &name, int rc,
                       int q) {
+  if (name.find("qsv") != std::string::npos) {
+    // https://github.com/LizardByte/Sunshine/blob/3e47cd3cc8fd37a7a88be82444ff4f3c0022856b/src/video.cpp#L1635
+    c->strict_std_compliance = FF_COMPLIANCE_UNOFFICIAL;
+  }
   std::vector<CodecOptions> codecs = {
       {"nvenc", "rc", {{RC_CBR, "cbr"}, {RC_VBR, "vbr"}}},
       {"amf", "rc", {{RC_CBR, "cbr"}, {RC_VBR, "vbr_latency"}}},


### PR DESCRIPTION
* Set `NalHrdConformance` to `MFX_CODINGOPTION_OFF` fix the issue for intel, https://github.com/Intel-Media-SDK/MediaSDK/blob/master/doc/mediasdk-man.md#dynamic-bitrate-change
  * For FFmpeg, set `strict_std_compliance` to `FF_COMPLIANCE_UNOFFICIAL`, https://github.com/FFmpeg/FFmpeg/blob/5f38c825367d205e969ecc013a0433adf0f7972b/libavcodec/qsvenc.c#L978
  * For SDK, set it to false directly
* Old sdk mfx create new encoder, change to reconfigure encoder, and some other paras are changed.
* Ram codecs are also tested.


https://github.com/user-attachments/assets/d5a2a9ad-5404-43d1-bb31-1a9905ee5318

https://github.com/user-attachments/assets/cbfb94c2-f9eb-45e9-8286-187b4c0fa75b

https://github.com/user-attachments/assets/e57c41d7-c5a3-42ad-9e06-79186fc39851

https://github.com/user-attachments/assets/b8fe46c6-5a89-4973-bd40-1354f7c08c76

https://github.com/user-attachments/assets/90460568-a013-4820-9c2f-f37fa0ed091c

https://github.com/user-attachments/assets/bb4d5282-f672-4007-a089-bc1d0a9eb812

