### PR TITLE
fixed could not find native static library `libmfx`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -156,7 +156,7 @@ mod ffmpeg {
         {
             let mut static_libs = vec!["avcodec", "avutil", "avformat"];
             if target_os == "windows" {
-                static_libs.push("libmfx");
+                static_libs.push("mfx");
             }
             static_libs
                 .iter()


### PR DESCRIPTION
When compiling and linking `libmfx` on Windows, the library name should be the same as the existing library name without the `lib` prefix. For example:

```rust
let mut static_libs = vec!["avcodec", "avutil", "avformat"];
```

fixed #34