### PR TITLE
add rate control mode (CBR/VBR/CQP) and QP parameter support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hwcodec"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,9 @@ fn build_common(builder: &mut Build) {
     // system
     #[cfg(windows)]
     {
-        ["d3d11", "dxgi"].map(|lib| println!("cargo:rustc-link-lib={}", lib));
+        for lib in ["d3d11", "dxgi"] {
+            println!("cargo:rustc-link-lib={}", lib);
+        }
     }
 
     builder.include(&common_dir);
@@ -80,7 +82,7 @@ fn build_common(builder: &mut Build) {
 struct CommonCallbacks;
 impl bindgen::callbacks::ParseCallbacks for CommonCallbacks {
     fn add_derives(&self, name: &str) -> Vec<String> {
-        let names = vec!["DataFormat", "SurfaceFormat", "API"];
+        let names = vec!["DataFormat", "SurfaceFormat", "API", "RateControl"];
         if names.contains(&name) {
             vec!["Serialize", "Deserialize"]
                 .drain(..)
@@ -305,11 +307,12 @@ mod sdk {
 
         // system
         #[cfg(target_os = "windows")]
-        [
+        for lib in [
             "kernel32", "user32", "gdi32", "winspool", "shell32", "ole32", "oleaut32", "uuid",
             "comdlg32", "advapi32", "d3d11", "dxgi",
-        ]
-        .map(|lib| println!("cargo:rustc-link-lib={}", lib));
+        ] {
+            println!("cargo:rustc-link-lib={}", lib);
+        };
         #[cfg(target_os = "linux")]
         println!("cargo:rustc-link-lib=stdc++");
 
@@ -446,11 +449,12 @@ mod sdk {
             );
 
         // link
-        [
+        for lib in [
             "kernel32", "user32", "gdi32", "winspool", "shell32", "ole32", "oleaut32", "uuid",
             "comdlg32", "advapi32", "d3d11", "dxgi",
-        ]
-        .map(|lib| println!("cargo:rustc-link-lib={}", lib));
+        ] {
+            println!("cargo:rustc-link-lib={}", lib)
+        };
 
         builder
             .files(["mfx_encode.cpp", "mfx_decode.cpp"].map(|f| mfx_dir.join(f)))

--- a/cpp/amf/amf_encode.cpp
+++ b/cpp/amf/amf_encode.cpp
@@ -60,6 +60,7 @@ public:
   DataFormat dataFormat_;
   amf::AMFComponentPtr AMFEncoder_ = NULL;
   amf::AMFContextPtr AMFContext_ = NULL;
+  int32_t rc_;
 
 private:
   // system
@@ -76,6 +77,9 @@ private:
   int32_t bitRateIn_;
   int32_t frameRate_;
   int32_t gop_;
+  int32_t qp_;
+  int32_t qp_min_;
+  int32_t qp_max_;
   bool enable4K_ = false;
   bool full_range_ = false;
   bool bt709_ = false;
@@ -86,15 +90,20 @@ private:
 public:
   AMFEncoder(void *handle, amf::AMF_MEMORY_TYPE memoryType, amf_wstring codec,
              DataFormat dataFormat, int32_t width, int32_t height,
-             int32_t bitrate, int32_t framerate, int32_t gop) {
+             int32_t bitrate, int32_t framerate, int32_t gop,
+             int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max) {
     handle_ = handle;
     dataFormat_ = dataFormat;
     AMFMemoryType_ = memoryType;
     resolution_ = std::make_pair(width, height);
     codec_ = codec;
-    bitRateIn_ = bitrate;
+    bitRateIn_ = bitrate > 0 ? bitrate : DEFAULT_KBS * 1000;
     frameRate_ = framerate;
     gop_ = (gop > 0 && gop < MAX_GOP) ? gop : MAX_GOP;
+    rc_ = rc;
+    qp_ = qp;
+    qp_min_ = qp_min;
+    qp_max_ = qp_max;
     enable4K_ = width > 1920 && height > 1080;
   }
 
@@ -259,10 +268,39 @@ private:
           AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_COLOR_BIT_DEPTH, eDepth_);
       AMF_CHECK_RETURN(res,
                        "SetProperty(AMF_VIDEO_ENCODER_COLOR_BIT_DEPTH  failed");
-      res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD,
-                                     AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR);
-      AMF_CHECK_RETURN(res,
-                       "SetProperty AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD");
+      if (rc_ == RC_CQP) {
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD,
+                                       AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CONSTANT_QP);
+        AMF_CHECK_RETURN(res,
+                         "SetProperty AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_QP_I, (amf_int64)qp_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_QP_I");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_QP_P, (amf_int64)qp_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_QP_P");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_QP_B, (amf_int64)qp_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_QP_B");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_MIN_QP, (amf_int64)qp_min_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_MIN_QP");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_MAX_QP, (amf_int64)qp_max_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_MAX_QP");
+      } else {
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD,
+                                       (rc_ == RC_VBR)
+                                           ? AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR
+                                           : AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR);
+        AMF_CHECK_RETURN(res,
+                         "SetProperty AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE,
+                                       bitRateIn_);
+        AMF_CHECK_RETURN(res,
+                         "SetProperty AMF_VIDEO_ENCODER_TARGET_BITRATE failed");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE,
+                                       (rc_ == RC_VBR)
+                                           ? util_encode::calc_vbr_max_rate(bitRateIn_)
+                                           : (int64_t)bitRateIn_);
+        AMF_CHECK_RETURN(res,
+                         "SetProperty AMF_VIDEO_ENCODER_PEAK_BITRATE failed");
+      }
       if (enable4K_) {
         res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_PROFILE,
                                        AMF_VIDEO_ENCODER_PROFILE_HIGH);
@@ -307,10 +345,6 @@ private:
                                      query_timeout_); // ms
       AMF_CHECK_RETURN(res,
                        "SetProperty AMF_VIDEO_ENCODER_QUERY_TIMEOUT failed");
-      res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE,
-                                     bitRateIn_);
-      AMF_CHECK_RETURN(res,
-                       "SetProperty AMF_VIDEO_ENCODER_TARGET_BITRATE failed");
       res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_FRAMERATE,
                                      ::AMFConstructRate(frameRate_, 1));
       AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_FRAMERATE failed");
@@ -348,11 +382,43 @@ private:
       AMF_CHECK_RETURN(
           res, "SetProperty AMF_VIDEO_ENCODER_HEVC_COLOR_BIT_DEPTH failed");
 
-      res = AMFEncoder_->SetProperty(
-          AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD,
-          AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR);
-      AMF_CHECK_RETURN(
-          res, "SetProperty AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD failed");
+      if (rc_ == RC_CQP) {
+        res = AMFEncoder_->SetProperty(
+            AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD,
+            AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CONSTANT_QP);
+        AMF_CHECK_RETURN(
+            res, "SetProperty AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD failed");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_QP_I, (amf_int64)qp_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_HEVC_QP_I");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_QP_P, (amf_int64)qp_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_HEVC_QP_P");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_MIN_QP_I, (amf_int64)qp_min_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_HEVC_MIN_QP_I");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_MIN_QP_P, (amf_int64)qp_min_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_HEVC_MIN_QP_P");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, (amf_int64)qp_max_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_HEVC_MAX_QP_I");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_P, (amf_int64)qp_max_);
+        AMF_CHECK_RETURN(res, "SetProperty AMF_VIDEO_ENCODER_HEVC_MAX_QP_P");
+      } else {
+        res = AMFEncoder_->SetProperty(
+            AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD,
+            (rc_ == RC_VBR)
+                ? AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR
+                : AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR);
+        AMF_CHECK_RETURN(
+            res, "SetProperty AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD failed");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE,
+                                       bitRateIn_);
+        AMF_CHECK_RETURN(
+            res, "SetProperty AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE failed");
+        res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE,
+                                       (rc_ == RC_VBR)
+                                           ? util_encode::calc_vbr_max_rate(bitRateIn_)
+                                           : (int64_t)bitRateIn_);
+        AMF_CHECK_RETURN(
+            res, "SetProperty AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE failed");
+      }
 
       if (enable4K_) {
         res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_TIER,
@@ -399,11 +465,6 @@ private:
                                      query_timeout_); // ms
       AMF_CHECK_RETURN(
           res, "SetProperty(AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT failed");
-
-      res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE,
-                                     bitRateIn_);
-      AMF_CHECK_RETURN(
-          res, "SetProperty AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE failed");
 
       res = AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMERATE,
                                      ::AMFConstructRate(frameRate_, 1));
@@ -471,9 +532,11 @@ int amf_destroy_encoder(void *encoder) {
 
 void *amf_new_encoder(void *handle, int64_t luid,
                       DataFormat dataFormat, int32_t width, int32_t height,
-                      int32_t kbs, int32_t framerate, int32_t gop) {
+                      int32_t kbs, int32_t framerate, int32_t gop,
+                      int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max) {
   AMFEncoder *enc = NULL;
   try {
+    util_encode::sanitize_qp(qp, qp_min, qp_max);
     amf_wstring codecStr;
     if (!convert_codec(dataFormat, codecStr)) {
       return NULL;
@@ -483,7 +546,7 @@ void *amf_new_encoder(void *handle, int64_t luid,
       return NULL;
     }
     enc = new AMFEncoder(handle, memoryType, codecStr, dataFormat, width,
-                         height, kbs * 1000, framerate, gop);
+                         height, kbs * 1000, framerate, gop, rc, qp, qp_min, qp_max);
     if (enc) {
       if (AMF_OK == enc->initialize()) {
         return enc;
@@ -527,7 +590,8 @@ int amf_driver_support() {
 int amf_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, int32_t *outDescNum,
                     DataFormat dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
-                    int32_t gop, const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount) {
+                    int32_t gop, int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max,
+                    const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount) {
   try {
     Adapters adapters;
     if (!adapters.Init(ADAPTER_VENDOR_AMD))
@@ -541,7 +605,7 @@ int amf_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, 
       
       AMFEncoder *e = (AMFEncoder *)amf_new_encoder(
           (void *)adapter.get()->device_.Get(), currentLuid,
-          dataFormat, width, height, kbs, framerate, gop);
+          dataFormat, width, height, kbs, framerate, gop, rc, qp, qp_min, qp_max);
       if (!e)
         continue;
       if (e->test() == AMF_OK) {
@@ -567,21 +631,87 @@ int amf_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, 
 int amf_set_bitrate(void *encoder, int32_t kbs) {
   try {
     AMFEncoder *enc = (AMFEncoder *)encoder;
+    if (enc->rc_ == RC_CQP) return 0;
     AMF_RESULT res = AMF_FAIL;
+    int64_t peakBitrate = (enc->rc_ == RC_VBR)
+        ? util_encode::calc_vbr_max_rate(kbs * 1000)
+        : (int64_t)(kbs * 1000);
     switch (enc->dataFormat_) {
     case H264:
       res = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE,
                                           kbs * 1000);
+      enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE,
+                                    peakBitrate);
       break;
     case H265:
       res = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE,
                                           kbs * 1000);
+      enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE,
+                                    peakBitrate);
       break;
     }
     return res == AMF_OK ? 0 : -1;
   } catch (const std::exception &e) {
     LOG_ERROR(std::string("set bitrate to ") + std::to_string(kbs) +
               "k failed: " + e.what());
+  }
+  return -1;
+}
+
+int amf_set_qp(void *encoder, int32_t qp, int32_t qp_min, int32_t qp_max) {
+  try {
+    AMFEncoder *enc = (AMFEncoder *)encoder;
+    if (enc->rc_ != RC_CQP) return 0;
+    util_encode::sanitize_qp(qp, qp_min, qp_max);
+    AMF_RESULT res = AMF_OK;
+    auto set_prop_checked = [&](const char *name, AMF_RESULT r) {
+      if (r != AMF_OK) {
+        LOG_ERROR(std::string("set qp property failed: ") +
+                  name + ", result code: " + std::to_string((int)r));
+        res = r;
+      }
+    };
+    switch (enc->dataFormat_) {
+    case H264: {
+      AMF_RESULT r = AMF_FAIL;
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_QP_I, (amf_int64)qp);
+      set_prop_checked("AMF_VIDEO_ENCODER_QP_I", r);
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_QP_P, (amf_int64)qp);
+      set_prop_checked("AMF_VIDEO_ENCODER_QP_P", r);
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_QP_B, (amf_int64)qp);
+      set_prop_checked("AMF_VIDEO_ENCODER_QP_B", r);
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_MIN_QP, (amf_int64)qp_min);
+      set_prop_checked("AMF_VIDEO_ENCODER_MIN_QP", r);
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_MAX_QP, (amf_int64)qp_max);
+      set_prop_checked("AMF_VIDEO_ENCODER_MAX_QP", r);
+      break;
+    }
+    case H265: {
+      AMF_RESULT r = AMF_FAIL;
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_QP_I, (amf_int64)qp);
+      set_prop_checked("AMF_VIDEO_ENCODER_HEVC_QP_I", r);
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_QP_P, (amf_int64)qp);
+      set_prop_checked("AMF_VIDEO_ENCODER_HEVC_QP_P", r);
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_MIN_QP_I, (amf_int64)qp_min);
+      set_prop_checked("AMF_VIDEO_ENCODER_HEVC_MIN_QP_I", r);
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_MIN_QP_P, (amf_int64)qp_min);
+      set_prop_checked("AMF_VIDEO_ENCODER_HEVC_MIN_QP_P", r);
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, (amf_int64)qp_max);
+      set_prop_checked("AMF_VIDEO_ENCODER_HEVC_MAX_QP_I", r);
+      r = enc->AMFEncoder_->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_P, (amf_int64)qp_max);
+      set_prop_checked("AMF_VIDEO_ENCODER_HEVC_MAX_QP_P", r);
+      break;
+    }
+    default:
+      res = AMF_FAIL;
+      LOG_ERROR(std::string("set qp failed: unsupported data format ") +
+                std::to_string((int)enc->dataFormat_));
+      break;
+    }
+    return res == AMF_OK ? 0 : -1;
+  } catch (const std::exception &e) {
+    LOG_ERROR(std::string("set qp to ") + std::to_string(qp) +
+              " failed: " + e.what());
   }
   return -1;
 }

--- a/cpp/amf/amf_ffi.h
+++ b/cpp/amf/amf_ffi.h
@@ -8,7 +8,8 @@ int amf_driver_support();
 
 void *amf_new_encoder(void *handle, int64_t luid,
                       int32_t data_format, int32_t width, int32_t height,
-                      int32_t bitrate, int32_t framerate, int32_t gop);
+                      int32_t bitrate, int32_t framerate, int32_t gop,
+                      int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max);
 
 int amf_encode(void *encoder, void *texture, EncodeCallback callback, void *obj,
                int64_t ms);
@@ -26,13 +27,16 @@ int amf_destroy_decoder(void *decoder);
 int amf_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, int32_t *outDescNum,
                     int32_t dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
-                    int32_t gop, const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
+                    int32_t gop, int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max,
+                    const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
 
 int amf_test_decode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, int32_t *outDescNum,
                     int32_t dataFormat, uint8_t *data,
                     int32_t length, const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
 
 int amf_set_bitrate(void *encoder, int32_t kbs);
+
+int amf_set_qp(void *encoder, int32_t qp, int32_t qp_min, int32_t qp_max);
 
 int amf_set_framerate(void *encoder, int32_t framerate);
 

--- a/cpp/common/common.h
+++ b/cpp/common/common.h
@@ -38,14 +38,16 @@ enum Vendor {
   VENDOR_FFMPEG = 3
 };
 
-enum Quality { Quality_Default, Quality_High, Quality_Medium, Quality_Low };
-
 enum RateControl {
-  RC_DEFAULT,
   RC_CBR,
   RC_VBR,
-  RC_CQ,
+  RC_CQP,
 };
+
+#define DEFAULT_QP     28
+#define DEFAULT_QP_MIN 22
+#define DEFAULT_QP_MAX 34
+#define DEFAULT_KBS    2000
 
 enum HwcodecErrno {
   HWCODEC_SUCCESS = 0,

--- a/cpp/common/util.cpp
+++ b/cpp/common/util.cpp
@@ -17,7 +17,14 @@ extern "C" {
 
 namespace util_encode {
 
-void set_av_codec_ctx(AVCodecContext *c, const std::string &name, int kbs,
+int64_t calc_vbr_max_rate(int64_t bit_rate) {
+  // Keep both relative and absolute headroom for VBR burst allocation.
+  const int64_t by_ratio = (bit_rate * 3) / 2;
+  const int64_t by_offset = bit_rate + 500000;
+  return by_ratio > by_offset ? by_ratio : by_offset;
+}
+
+void set_av_codec_ctx(AVCodecContext *c, const std::string &name,
                       int gop, int fps) {
   c->has_b_frames = 0;
   c->max_b_frames = 0;
@@ -31,15 +38,6 @@ void set_av_codec_ctx(AVCodecContext *c, const std::string &name, int kbs,
     c->gop_size = std::numeric_limits<int>::max();
   }
   c->keyint_min = std::numeric_limits<int>::max();
-  /* put sample parameters */
-  // https://github.com/FFmpeg/FFmpeg/blob/415f012359364a77e8394436f222b74a8641a3ee/libavcodec/encode.c#L581
-  if (kbs > 0) {
-    c->bit_rate = kbs * 1000;
-    if (name.find("qsv") != std::string::npos) {
-      c->rc_max_rate = c->bit_rate;
-      c->bit_rate--; // cbr with vbr
-    }
-  }
   /* frames per second */
   c->time_base = av_make_q(1, 1000);
   c->framerate = av_make_q(fps, 1);
@@ -102,142 +100,160 @@ bool set_lantency_free(void *priv_data, const std::string &name) {
   return true;
 }
 
-bool set_quality(void *priv_data, const std::string &name, int quality) {
-  int ret = -1;
-
-  if (name.find("nvenc") != std::string::npos) {
-    switch (quality) {
-    // p7 isn't zero lantency
-    case Quality_Medium:
-      if ((ret = av_opt_set(priv_data, "preset", "p4", 0)) < 0) {
-        LOG_ERROR(std::string("nvenc set opt preset p4 failed, ret = ") + av_err2str(ret));
-        return false;
-      }
-      break;
-    case Quality_Low:
-      if ((ret = av_opt_set(priv_data, "preset", "p1", 0)) < 0) {
-        LOG_ERROR(std::string("nvenc set opt preset p1 failed, ret = ") + av_err2str(ret));
-        return false;
-      }
-      break;
-    default:
-      break;
-    }
-  }
-  if (name.find("amf") != std::string::npos) {
-    switch (quality) {
-    case Quality_High:
-      if ((ret = av_opt_set(priv_data, "quality", "quality", 0)) < 0) {
-        LOG_ERROR(std::string("amf set opt quality quality failed, ret = ") +
-                  av_err2str(ret));
-        return false;
-      }
-      break;
-    case Quality_Medium:
-      if ((ret = av_opt_set(priv_data, "quality", "balanced", 0)) < 0) {
-        LOG_ERROR(std::string("amf set opt quality balanced failed, ret = ") +
-                  av_err2str(ret));
-        return false;
-      }
-      break;
-    case Quality_Low:
-      if ((ret = av_opt_set(priv_data, "quality", "speed", 0)) < 0) {
-        LOG_ERROR(std::string("amf set opt quality speed failed, ret = ") + av_err2str(ret));
-        return false;
-      }
-      break;
-    default:
-      break;
-    }
-  }
-  if (name.find("qsv") != std::string::npos) {
-    switch (quality) {
-    case Quality_High:
-      if ((ret = av_opt_set(priv_data, "preset", "veryslow", 0)) < 0) {
-        LOG_ERROR(std::string("qsv set opt preset veryslow failed, ret = ") +
-                  av_err2str(ret));
-        return false;
-      }
-      break;
-    case Quality_Medium:
-      if ((ret = av_opt_set(priv_data, "preset", "medium", 0)) < 0) {
-        LOG_ERROR(std::string("qsv set opt preset medium failed, ret = ") + av_err2str(ret));
-        return false;
-      }
-      break;
-    case Quality_Low:
-      if ((ret = av_opt_set(priv_data, "preset", "veryfast", 0)) < 0) {
-        LOG_ERROR(std::string("qsv set opt preset veryfast failed, ret = ") +
-                  av_err2str(ret));
-        return false;
-      }
-      break;
-    default:
-      break;
-    }
-  }
-  if (name.find("mediacodec") != std::string::npos) {
-    if (name.find("h264") != std::string::npos) {
-      if ((ret = av_opt_set(priv_data, "level", "5.1", 0)) < 0) {
-        LOG_ERROR(std::string("mediacodec set opt level 5.1 failed, ret = ") +
-                  av_err2str(ret));
-        return false;
-      }
-    }
-    if (name.find("hevc") != std::string::npos) {
-      // https:en.wikipedia.org/wiki/High_Efficiency_Video_Coding_tiers_and_levels
-      if ((ret = av_opt_set(priv_data, "level", "h5.1", 0)) < 0) {
-        LOG_ERROR(std::string("mediacodec set opt level h5.1 failed, ret = ") +
-                  av_err2str(ret));
-        return false;
-      }
-    }
-  }
-  return true;
+static int clamp_qp(int qp) {
+  if (qp < 0) return 0;
+  if (qp > 51) return 51;
+  return qp;
 }
 
-struct CodecOptions {
-  std::string codec_name;
-  std::string option_name;
-  std::map<int, std::string> rc_values;
-};
+static int ensure_kbs(int kbs) {
+  return kbs > 0 ? kbs : DEFAULT_KBS;
+}
+
+void sanitize_qp(int &qp, int &qp_min, int &qp_max) {
+  if (qp <= 0) qp = DEFAULT_QP;
+  if (qp_min <= 0) qp_min = DEFAULT_QP_MIN;
+  if (qp_max <= 0) qp_max = DEFAULT_QP_MAX;
+  qp = clamp_qp(qp);
+  qp_min = clamp_qp(qp_min);
+  qp_max = clamp_qp(qp_max);
+  if (qp_min > qp) qp_min = qp;
+  if (qp_max < qp) qp_max = qp;
+}
+
+static void apply_nvenc_qp(AVCodecContext *c, int qp) {
+  av_opt_set(c->priv_data, "rc", "constqp", 0);
+  av_opt_set_int(c->priv_data, "qp", qp, 0);
+}
+
+static void apply_amf_qp(AVCodecContext *c, const std::string &name,
+                          int qp, int qp_min, int qp_max) {
+  av_opt_set(c->priv_data, "rc", "cqp", 0);
+  av_opt_set_int(c->priv_data, "vbaq", 0, 0);
+  av_opt_set_int(c->priv_data, "qp_i", qp, 0);
+  av_opt_set_int(c->priv_data, "qp_p", qp, 0);
+  if (name.find("h264") != std::string::npos) {
+    av_opt_set_int(c->priv_data, "qp_b", qp, 0);
+  }
+  if (qp_min > 0) c->qmin = qp_min;
+  if (qp_max > 0) c->qmax = qp_max;
+}
+
+static void apply_qsv_qp(AVCodecContext *c, int qp, int qp_min, int qp_max) {
+  c->global_quality = qp * FF_QP2LAMBDA;
+  if (qp_min > 0) c->qmin = qp_min;
+  if (qp_max > 0) c->qmax = qp_max;
+}
+
+static void set_cqp_common(AVCodecContext *c) {
+  c->flags |= AV_CODEC_FLAG_QSCALE;
+  c->bit_rate = 0;
+  c->rc_max_rate = 0;
+}
 
 bool set_rate_control(AVCodecContext *c, const std::string &name, int rc,
-                      int q) {
-  if (name.find("qsv") != std::string::npos) {
-    // https://github.com/LizardByte/Sunshine/blob/3e47cd3cc8fd37a7a88be82444ff4f3c0022856b/src/video.cpp#L1635
-    c->strict_std_compliance = FF_COMPLIANCE_UNOFFICIAL;
-  }
-  std::vector<CodecOptions> codecs = {
-      {"nvenc", "rc", {{RC_CBR, "cbr"}, {RC_VBR, "vbr"}}},
-      {"amf", "rc", {{RC_CBR, "cbr"}, {RC_VBR, "vbr_latency"}}},
-      {"mediacodec",
-       "bitrate_mode",
-       {{RC_CBR, "cbr"}, {RC_VBR, "vbr"}, {RC_CQ, "cq"}}},
-      // {"videotoolbox", "constant_bit_rate", {{RC_CBR, "1"}}},
-    };
+                      int kbs, int qp, int qp_min, int qp_max) {
+  int ret;
 
-  for (const auto &codec : codecs) {
-    if (name.find(codec.codec_name) != std::string::npos) {
-      auto it = codec.rc_values.find(rc);
-      if (it != codec.rc_values.end()) {
-        int ret = av_opt_set(c->priv_data, codec.option_name.c_str(),
-                             it->second.c_str(), 0);
-        if (ret < 0) {
-          LOG_ERROR(codec.codec_name + " set opt " + codec.option_name + " " +
-                    it->second + " failed, ret = " + av_err2str(ret));
-          return false;
-        }
-        if (name.find("mediacodec") != std::string::npos) {
-          if (rc == RC_CQ) {
-            if (q >= 0 && q <= 51) {
-              c->global_quality = q;
-            }
-          }
-        }
+  if (name.find("qsv") != std::string::npos) {
+    c->strict_std_compliance = FF_COMPLIANCE_UNOFFICIAL;
+    if (rc == RC_CQP) {
+      sanitize_qp(qp, qp_min, qp_max);
+      set_cqp_common(c);
+      apply_qsv_qp(c, qp, qp_min, qp_max);
+    } else {
+      kbs = ensure_kbs(kbs);
+      c->bit_rate = kbs * 1000;
+      if (rc == RC_VBR) {
+        c->rc_max_rate = calc_vbr_max_rate(c->bit_rate);
+      } else if (rc == RC_CBR) {
+        c->rc_max_rate = c->bit_rate;
       }
-      break;
     }
+    struct QsvOpt {
+      const char *name;
+      int64_t value;
+    };
+    const QsvOpt qsv_opts[] = {
+        {"preset", 5},
+        {"scenario", 1},
+        {"adaptive_i", 1},
+        {"adaptive_b", 0},
+        {"b_strategy", 0},
+    };
+    for (const auto &opt : qsv_opts) {
+      ret = av_opt_set_int(c->priv_data, opt.name, opt.value, 0);
+      if (ret < 0) {
+        LOG_WARN(std::string("qsv set opt ") + opt.name + "=" +
+                 std::to_string(opt.value) + " failed, ret = " + av_err2str(ret));
+      }
+    }
+    if (rc != RC_CQP) {
+      av_opt_set_int(c->priv_data, "mbbrc", 1, 0);
+      // av_opt_set_int(c->priv_data, "extbrc", 1, 0); // extbrc causes bitrate spikes for h264, keep it disabled
+    }
+  } else if (name.find("nvenc") != std::string::npos) {
+    if (rc == RC_CQP) {
+      sanitize_qp(qp, qp_min, qp_max);
+      set_cqp_common(c);
+      apply_nvenc_qp(c, qp);
+    } else {
+      kbs = ensure_kbs(kbs);
+      c->bit_rate = kbs * 1000;
+      if (rc == RC_CBR) {
+        av_opt_set(c->priv_data, "rc", "cbr", 0);
+        c->rc_max_rate = c->bit_rate;
+      } else if (rc == RC_VBR) {
+        av_opt_set(c->priv_data, "rc", "vbr", 0);
+        c->rc_max_rate = calc_vbr_max_rate(c->bit_rate);
+      }
+    }
+  } else if (name.find("amf") != std::string::npos) {
+    if (rc == RC_CQP) {
+      sanitize_qp(qp, qp_min, qp_max);
+      set_cqp_common(c);
+      apply_amf_qp(c, name, qp, qp_min, qp_max);
+    } else {
+      kbs = ensure_kbs(kbs);
+      c->bit_rate = kbs * 1000;
+      if (rc == RC_CBR) {
+        av_opt_set(c->priv_data, "rc", "hqcbr", 0);
+        c->rc_max_rate = c->bit_rate;
+        c->rc_buffer_size = c->bit_rate * 2;
+      } else if (rc == RC_VBR) {
+        av_opt_set(c->priv_data, "rc", "hqvbr", 0);
+        c->rc_max_rate = calc_vbr_max_rate(c->bit_rate);
+        c->rc_buffer_size = c->rc_max_rate * 2;
+      }
+      c->rc_initial_buffer_occupancy = c->rc_buffer_size;
+      av_opt_set(c->priv_data, "quality", "quality", 0);
+    }
+  } else if (name.find("mediacodec") != std::string::npos) {
+    kbs = ensure_kbs(kbs);
+    c->bit_rate = kbs * 1000;
+    if (rc == RC_CBR) {
+      av_opt_set(c->priv_data, "bitrate_mode", "cbr", 0);
+    } else if (rc == RC_VBR) {
+      av_opt_set(c->priv_data, "bitrate_mode", "vbr", 0);
+    }
+  } else if (name.find("vaapi") != std::string::npos) {
+    kbs = ensure_kbs(kbs);
+    c->bit_rate = kbs * 1000;
+    if ((ret = av_opt_set_int(c->priv_data, "idr_interval",
+                              std::numeric_limits<int>::max(), 0)) < 0) {
+      LOG_ERROR(std::string("vaapi set idr_interval failed, ret = ") + av_err2str(ret));
+    }
+  } else if (name.find("_mf") != std::string::npos) {
+    kbs = ensure_kbs(kbs);
+    c->bit_rate = kbs * 1000;
+    if ((ret = av_opt_set_int(c->priv_data, "scenario", 1, 0)) < 0) {
+      LOG_ERROR(std::string("mediafoundation set scenario failed, ret = ") +
+                av_err2str(ret));
+    }
+  } else {
+    // fallback for other codecs (videotoolbox, etc.)
+    kbs = ensure_kbs(kbs);
+    c->bit_rate = kbs * 1000;
   }
 
   return true;
@@ -274,32 +290,43 @@ bool force_hw(void *priv_data, const std::string &name) {
   return true;
 }
 
-bool set_others(void *priv_data, const std::string &name) {
-  int ret;
-  if (name.find("_mf") != std::string::npos) {
-    // ff_eAVScenarioInfo_DisplayRemoting = 1
-    if ((ret = av_opt_set_int(priv_data, "scenario", 1, 0)) < 0) {
-      LOG_ERROR(std::string("mediafoundation set scenario failed, ret = ") +
-                av_err2str(ret));
-      return false;
+bool is_using_cqp(const std::string &name, AVCodecContext *c) {
+  (void)name;
+  return c && (c->flags & AV_CODEC_FLAG_QSCALE);
+}
+
+bool change_qp(AVCodecContext *c, const std::string &name, int qp, int qp_min,
+               int qp_max) {
+  if (!is_using_cqp(name, c)) return true;
+  sanitize_qp(qp, qp_min, qp_max);
+  if (name.find("nvenc") != std::string::npos) {
+    av_opt_set_int(c->priv_data, "qp", qp, 0);
+  } else if (name.find("amf") != std::string::npos) {
+    av_opt_set_int(c->priv_data, "qp_i", qp, 0);
+    av_opt_set_int(c->priv_data, "qp_p", qp, 0);
+    if (name.find("h264") != std::string::npos) {
+      av_opt_set_int(c->priv_data, "qp_b", qp, 0);
     }
-  }
-  if (name.find("vaapi") != std::string::npos) {
-    if ((ret = av_opt_set_int(priv_data, "idr_interval",
-                              std::numeric_limits<int>::max(), 0)) < 0) {
-      LOG_ERROR(std::string("vaapi set idr_interval failed, ret = ") + av_err2str(ret));
-      return false;
-    }
+    if (qp_min > 0) c->qmin = qp_min;
+    if (qp_max > 0) c->qmax = qp_max;
+  } else if (name.find("qsv") != std::string::npos) {
+    apply_qsv_qp(c, qp, qp_min, qp_max);
   }
   return true;
 }
 
-bool change_bit_rate(AVCodecContext *c, const std::string &name, int kbs) {
-  if (kbs > 0) {
-    c->bit_rate = kbs * 1000;
-    if (name.find("qsv") != std::string::npos) {
-      c->rc_max_rate = c->bit_rate;
-    }
+bool change_bit_rate(AVCodecContext *c, const std::string &name, int rc, int kbs) {
+  if (is_using_cqp(name, c)) return true;
+  kbs = ensure_kbs(kbs);
+  c->bit_rate = kbs * 1000;
+  if (rc == RC_VBR) {
+    c->rc_max_rate = calc_vbr_max_rate(c->bit_rate);
+  } else {
+    c->rc_max_rate = c->bit_rate;
+  }
+  if (name.find("amf") != std::string::npos) {
+    c->rc_buffer_size = c->rc_max_rate * 2;
+    c->rc_initial_buffer_occupancy = c->rc_buffer_size;
   }
   return true;
 }

--- a/cpp/common/util.h
+++ b/cpp/common/util.h
@@ -9,17 +9,19 @@ extern "C" {
 
 namespace util_encode {
 
-void set_av_codec_ctx(AVCodecContext *c, const std::string &name, int kbs,
+void set_av_codec_ctx(AVCodecContext *c, const std::string &name,
                       int gop, int fps);
 bool set_lantency_free(void *priv_data, const std::string &name);
-bool set_quality(void *priv_data, const std::string &name, int quality);
 bool set_rate_control(AVCodecContext *c, const std::string &name, int rc,
-                      int q);
+                      int kbs, int qp, int qp_min, int qp_max);
 bool set_gpu(void *priv_data, const std::string &name, int gpu);
 bool force_hw(void *priv_data, const std::string &name);
-bool set_others(void *priv_data, const std::string &name);
+void sanitize_qp(int &qp, int &qp_min, int &qp_max);
+int64_t calc_vbr_max_rate(int64_t bit_rate);
 
-bool change_bit_rate(AVCodecContext *c, const std::string &name, int kbs);
+bool is_using_cqp(const std::string &name, AVCodecContext *c);
+bool change_qp(AVCodecContext *c, const std::string &name, int qp, int qp_min, int qp_max);
+bool change_bit_rate(AVCodecContext *c, const std::string &name, int rc, int kbs);
 void vram_encode_test_callback(const uint8_t *data, int32_t len, int32_t key, const void *obj, int64_t pts);
 
 } // namespace util

--- a/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
@@ -107,12 +107,12 @@ public:
   AVPixelFormat pixfmt_ = AV_PIX_FMT_NV12;
   int align_ = 0;
   int rc_ = 0;
-  int quality_ = 0;
   int kbs_ = 0;
-  int q_ = 0;
+  int qp_ = 0;
+  int qp_min_ = 0;
+  int qp_max_ = 0;
   int fps_ = 30;
   int gop_ = 0xFFFF;
-  int thread_count_ = 1;
   int gpu_ = 0;
   RamEncodeCallback callback_ = NULL;
   int offset_[AV_NUM_DATA_POINTERS] = {0};
@@ -123,8 +123,8 @@ public:
   AVFrame *hw_frame_ = NULL;
 
   FFmpegRamEncoder(const char *name, const char *mc_name, int width, int height,
-                   int pixfmt, int align, int fps, int gop, int rc, int quality,
-                   int kbs, int q, int thread_count, int gpu,
+                   int pixfmt, int align, int fps, int gop, int rc,
+                   int kbs, int qp, int qp_min, int qp_max, int gpu,
                    RamEncodeCallback callback) {
     name_ = name;
     mc_name_ = mc_name ? mc_name : "";
@@ -135,10 +135,10 @@ public:
     fps_ = fps;
     gop_ = gop;
     rc_ = rc;
-    quality_ = quality;
     kbs_ = kbs;
-    q_ = q;
-    thread_count_ = thread_count;
+    qp_ = qp;
+    qp_min_ = qp_min;
+    qp_max_ = qp_max;
     gpu_ = gpu;
     callback_ = callback;
     if (name_.find("vaapi") != std::string::npos) {
@@ -230,16 +230,14 @@ public:
     c_->pix_fmt =
         hw_pixfmt_ != AV_PIX_FMT_NONE ? hw_pixfmt_ : (AVPixelFormat)pixfmt_;
     c_->sw_pix_fmt = (AVPixelFormat)pixfmt_;
-    util_encode::set_av_codec_ctx(c_, name_, kbs_, gop_, fps_);
+    util_encode::set_av_codec_ctx(c_, name_, gop_, fps_);
     if (!util_encode::set_lantency_free(c_->priv_data, name_)) {
       LOG_ERROR(std::string("set_lantency_free failed, name: ") + name_);
       return false;
     }
-    // util_encode::set_quality(c_->priv_data, name_, quality_);
-    util_encode::set_rate_control(c_, name_, rc_, q_);
+    util_encode::set_rate_control(c_, name_, rc_, kbs_, qp_, qp_min_, qp_max_);
     util_encode::set_gpu(c_->priv_data, name_, gpu_);
     util_encode::force_hw(c_->priv_data, name_);
-    util_encode::set_others(c_->priv_data, name_);
     if (name_.find("mediacodec") != std::string::npos) {
       if (mc_name_.length() > 0) {
         LOG_INFO(std::string("mediacodec codec_name: ") + mc_name_);
@@ -304,7 +302,11 @@ public:
   }
 
   int set_bitrate(int kbs) {
-    return util_encode::change_bit_rate(c_, name_, kbs) ? 0 : -1;
+    return util_encode::change_bit_rate(c_, name_, rc_, kbs) ? 0 : -1;
+  }
+
+  int set_qp(int qp, int qp_min, int qp_max) {
+    return util_encode::change_qp(c_, name_, qp, qp_min, qp_max) ? 0 : -1;
   }
 
 private:
@@ -410,13 +412,13 @@ private:
 extern "C" FFmpegRamEncoder *
 ffmpeg_ram_new_encoder(const char *name, const char *mc_name, int width,
                        int height, int pixfmt, int align, int fps, int gop,
-                       int rc, int quality, int kbs, int q, int thread_count,
-                       int gpu, int *linesize, int *offset, int *length,
-                       RamEncodeCallback callback) {
+                       int rc, int kbs, int qp, int qp_min, int qp_max,
+                       int gpu, int *linesize, int *offset,
+                       int *length, RamEncodeCallback callback) {
   FFmpegRamEncoder *encoder = NULL;
   try {
     encoder = new FFmpegRamEncoder(name, mc_name, width, height, pixfmt, align,
-                                   fps, gop, rc, quality, kbs, q, thread_count,
+                                   fps, gop, rc, kbs, qp, qp_min, qp_max,
                                    gpu, callback);
     if (encoder) {
       if (encoder->init(linesize, offset, length)) {
@@ -461,6 +463,16 @@ extern "C" int ffmpeg_ram_set_bitrate(FFmpegRamEncoder *encoder, int kbs) {
     return encoder->set_bitrate(kbs);
   } catch (const std::exception &e) {
     LOG_ERROR(std::string("ffmpeg_ram_set_bitrate failed, ") + std::string(e.what()));
+  }
+  return -1;
+}
+
+extern "C" int ffmpeg_ram_set_qp(FFmpegRamEncoder *encoder, int qp, int qp_min,
+                                  int qp_max) {
+  try {
+    return encoder->set_qp(qp, qp_min, qp_max);
+  } catch (const std::exception &e) {
+    LOG_ERROR(std::string("ffmpeg_ram_set_qp failed, ") + std::string(e.what()));
   }
   return -1;
 }

--- a/cpp/ffmpeg_ram/ffmpeg_ram_ffi.h
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_ffi.h
@@ -14,8 +14,9 @@ typedef void (*RamEncodeCallback)(const uint8_t *data, int len, int64_t pts,
 
 void *ffmpeg_ram_new_encoder(const char *name, const char *mc_name, int width,
                              int height, int pixfmt, int align, int fps,
-                             int gop, int rc, int quality, int kbs, int q,
-                             int thread_count, int gpu, int *linesize,
+                             int gop, int rc, int kbs, int qp,
+                             int qp_min, int qp_max,
+                             int gpu, int *linesize,
                              int *offset, int *length,
                              RamEncodeCallback callback);
 void *ffmpeg_ram_new_decoder(const char *name, int device_type,
@@ -30,5 +31,6 @@ int ffmpeg_ram_get_linesize_offset_length(int pix_fmt, int width, int height,
                                           int align, int *linesize, int *offset,
                                           int *length);
 int ffmpeg_ram_set_bitrate(void *encoder, int kbs);
+int ffmpeg_ram_set_qp(void *encoder, int qp, int qp_min, int qp_max);
 
 #endif // FFMPEG_RAM_FFI_H

--- a/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_encode.cpp
@@ -76,13 +76,18 @@ public:
   int32_t kbs_;
   int32_t framerate_;
   int32_t gop_;
+  int32_t rc_;
+  int32_t qp_ = 0;
+  int32_t qp_min_ = 0;
+  int32_t qp_max_ = 0;
 
   const int align_ = 0;
   const bool full_range_ = false;
   const bool bt709_ = false;
   FFmpegVRamEncoder(void *handle, int64_t luid, DataFormat dataFormat,
                     int32_t width, int32_t height, int32_t kbs,
-                    int32_t framerate, int32_t gop) {
+                    int32_t framerate, int32_t gop,
+                    int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max) {
     handle_ = handle;
     luid_ = luid;
     dataFormat_ = dataFormat;
@@ -91,6 +96,10 @@ public:
     kbs_ = kbs;
     framerate_ = framerate;
     gop_ = gop;
+    rc_ = rc;
+    qp_ = qp;
+    qp_min_ = qp_min;
+    qp_max_ = qp_max;
   }
 
   ~FFmpegVRamEncoder() {}
@@ -129,13 +138,11 @@ public:
     c_->height = height_;
     c_->pix_fmt = encoder_->hw_pixfmt_;
     c_->sw_pix_fmt = encoder_->sw_pixfmt_;
-    util_encode::set_av_codec_ctx(c_, encoder_->name_, kbs_, gop_, framerate_);
+    util_encode::set_av_codec_ctx(c_, encoder_->name_, gop_, framerate_);
     if (!util_encode::set_lantency_free(c_->priv_data, encoder_->name_)) {
       return false;
     }
-    // util_encode::set_quality(c_->priv_data, encoder_->name_, Quality_Default);
-    util_encode::set_rate_control(c_, encoder_->name_, RC_CBR, -1);
-    util_encode::set_others(c_->priv_data, encoder_->name_);
+    util_encode::set_rate_control(c_, encoder_->name_, rc_, kbs_, qp_, qp_min_, qp_max_);
 
     hw_device_ctx_ = av_hwdevice_ctx_alloc(encoder_->device_type_);
     if (!hw_device_ctx_) {
@@ -252,7 +259,11 @@ public:
   }
 
   int set_bitrate(int kbs) {
-    return util_encode::change_bit_rate(c_, encoder_->name_, kbs) ? 0 : -1;
+    return util_encode::change_bit_rate(c_, encoder_->name_, rc_, kbs) ? 0 : -1;
+  }
+
+  int set_qp(int qp, int qp_min, int qp_max) {
+    return util_encode::change_qp(c_, encoder_->name_, qp, qp_min, qp_max) ? 0 : -1;
   }
 
   int set_framerate(int framerate) {
@@ -432,11 +443,14 @@ extern "C" {
 FFmpegVRamEncoder *ffmpeg_vram_new_encoder(void *handle, int64_t luid,
                                            DataFormat dataFormat, int32_t width,
                                            int32_t height, int32_t kbs,
-                                           int32_t framerate, int32_t gop) {
+                                           int32_t framerate, int32_t gop,
+                                           int32_t rc, int32_t qp, int32_t qp_min,
+                                           int32_t qp_max) {
   FFmpegVRamEncoder *encoder = NULL;
   try {
     encoder = new FFmpegVRamEncoder(handle, luid, dataFormat, width,
-                                    height, kbs, framerate, gop);
+                                    height, kbs, framerate, gop,
+                                    rc, qp, qp_min, qp_max);
     if (encoder) {
       if (encoder->init()) {
         return encoder;
@@ -479,7 +493,17 @@ int ffmpeg_vram_set_bitrate(FFmpegVRamEncoder *encoder, int kbs) {
   try {
     return encoder->set_bitrate(kbs);
   } catch (const std::exception &e) {
-    LOG_ERROR(std::string("ffmpeg_ram_set_bitrate failed, ") + std::string(e.what()));
+    LOG_ERROR(std::string("ffmpeg_vram_set_bitrate failed, ") + std::string(e.what()));
+  }
+  return -1;
+}
+
+int ffmpeg_vram_set_qp(FFmpegVRamEncoder *encoder, int32_t qp, int32_t qp_min,
+                        int32_t qp_max) {
+  try {
+    return encoder->set_qp(qp, qp_min, qp_max);
+  } catch (const std::exception &e) {
+    LOG_ERROR(std::string("ffmpeg_vram_set_qp failed, ") + std::string(e.what()));
   }
   return -1;
 }
@@ -497,6 +521,7 @@ int ffmpeg_vram_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxD
                             int32_t *outDescNum, DataFormat dataFormat,
                             int32_t width, int32_t height, int32_t kbs,
                             int32_t framerate, int32_t gop,
+                            int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max,
                             const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount) {
   try {
     int count = 0;
@@ -522,7 +547,7 @@ int ffmpeg_vram_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxD
         
         FFmpegVRamEncoder *e = (FFmpegVRamEncoder *)ffmpeg_vram_new_encoder(
             (void *)adapter.get()->device_.Get(), currentLuid,
-            dataFormat, width, height, kbs, framerate, gop);
+            dataFormat, width, height, kbs, framerate, gop, rc, qp, qp_min, qp_max);
         if (!e)
           continue;
         if (e->native_->EnsureTexture(e->width_, e->height_)) {

--- a/cpp/ffmpeg_vram/ffmpeg_vram_ffi.h
+++ b/cpp/ffmpeg_vram/ffmpeg_vram_ffi.h
@@ -15,7 +15,8 @@ int ffmpeg_vram_test_decode(int64_t *outLuids, int32_t *outVendors, int32_t maxD
                             const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
 void *ffmpeg_vram_new_encoder(void *handle, int64_t luid,
                               int32_t dataFormat, int32_t width, int32_t height,
-                              int32_t kbs, int32_t framerate, int32_t gop);
+                              int32_t kbs, int32_t framerate, int32_t gop,
+                              int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max);
 
 int ffmpeg_vram_encode(void *encoder, void *tex, EncodeCallback callback,
                        void *obj, int64_t ms);
@@ -25,8 +26,10 @@ int ffmpeg_vram_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxD
                             int32_t *outDescNum,
                             int32_t dataFormat, int32_t width, int32_t height,
                             int32_t kbs, int32_t framerate, int32_t gop,
+                            int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max,
                             const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
 int ffmpeg_vram_set_bitrate(void *encoder, int32_t kbs);
+int ffmpeg_vram_set_qp(void *encoder, int32_t qp, int32_t qp_min, int32_t qp_max);
 int ffmpeg_vram_set_framerate(void *encoder, int32_t framerate);
 
 #endif // FFMPEG_VRAM_FFI_H

--- a/cpp/mfx/mfx_encode.cpp
+++ b/cpp/mfx/mfx_encode.cpp
@@ -83,13 +83,17 @@ public:
   int32_t kbs_;
   int32_t framerate_;
   int32_t gop_;
+  int32_t rc_;
+  int32_t qp_;
+  int32_t qp_min_;
+  int32_t qp_max_;
 
   bool full_range_ = false;
   bool bt709_ = false;
 
   VplEncoder(void *handle, int64_t luid, DataFormat dataFormat,
              int32_t width, int32_t height, int32_t kbs, int32_t framerate,
-             int32_t gop) {
+             int32_t gop, int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max) {
     handle_ = handle;
     luid_ = luid;
     dataFormat_ = dataFormat;
@@ -98,6 +102,10 @@ public:
     kbs_ = kbs;
     framerate_ = framerate;
     gop_ = gop;
+    rc_ = rc;
+    qp_ = qp;
+    qp_min_ = qp_min;
+    qp_max_ = qp_max;
   }
 
   ~VplEncoder() {}
@@ -339,11 +347,25 @@ private:
     // quality
     // https://www.intel.com/content/www/us/en/developer/articles/technical/common-bitrate-control-methods-in-intel-media-sdk.html
     mfxEncParams_.mfx.TargetUsage = MFX_TARGETUSAGE_BEST_SPEED;
-    mfxEncParams_.mfx.RateControlMethod = MFX_RATECONTROL_VBR;
-    mfxEncParams_.mfx.InitialDelayInKB = 0;
-    mfxEncParams_.mfx.BufferSizeInKB = 512;
-    mfxEncParams_.mfx.TargetKbps = kbs_;
-    mfxEncParams_.mfx.MaxKbps = kbs_;
+    if (rc_ == RC_CQP) {
+      mfxEncParams_.mfx.RateControlMethod = MFX_RATECONTROL_CQP;
+      mfxEncParams_.mfx.QPI = qp_;
+      mfxEncParams_.mfx.QPP = qp_;
+      mfxEncParams_.mfx.QPB = qp_;
+    } else {
+      if (kbs_ <= 0) kbs_ = DEFAULT_KBS;
+      mfxEncParams_.mfx.RateControlMethod =
+          (rc_ == RC_VBR) ? MFX_RATECONTROL_VBR : MFX_RATECONTROL_CBR;
+      int32_t maxKbps = (rc_ == RC_VBR)
+          ? (int32_t)(util_encode::calc_vbr_max_rate((int64_t)kbs_ * 1000) / 1000)
+          : kbs_;
+      int32_t topKbps = (maxKbps > kbs_) ? maxKbps : kbs_;
+      mfxU16 brc_mul = (topKbps > 0xFFFF)
+          ? (mfxU16)((topKbps + 0xFFFE) / 0xFFFF) : 1;
+      mfxEncParams_.mfx.BRCParamMultiplier = brc_mul;
+      mfxEncParams_.mfx.TargetKbps = (mfxU16)(kbs_ / brc_mul);
+      mfxEncParams_.mfx.MaxKbps = (mfxU16)(maxKbps / brc_mul);
+    }
     mfxEncParams_.mfx.NumSlice = 1;
     mfxEncParams_.mfx.NumRefFrame = 0;
 
@@ -532,6 +554,18 @@ private:
     coding_option2_.Header.BufferId = MFX_EXTBUFF_CODING_OPTION2;
     coding_option2_.Header.BufferSz = sizeof(mfxExtCodingOption2);
     coding_option2_.RepeatPPS = MFX_CODINGOPTION_OFF;
+    if (qp_min_ > 0) {
+      mfxU16 v = qp_min_ > 51 ? 51 : qp_min_;
+      coding_option2_.MinQPI = v;
+      coding_option2_.MinQPP = v;
+      coding_option2_.MinQPB = v;
+    }
+    if (qp_max_ > 0) {
+      mfxU16 v = qp_max_ > 51 ? 51 : qp_max_;
+      coding_option2_.MaxQPI = v;
+      coding_option2_.MaxQPP = v;
+      coding_option2_.MaxQPB = v;
+    }
     extbuffers_[1] = (mfxExtBuffer *)&coding_option2_;
 
     // coding option3
@@ -594,11 +628,13 @@ int mfx_destroy_encoder(void *encoder) {
 
 void *mfx_new_encoder(void *handle, int64_t luid,
                       DataFormat dataFormat, int32_t w, int32_t h, int32_t kbs,
-                      int32_t framerate, int32_t gop) {
+                      int32_t framerate, int32_t gop,
+                      int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max) {
   VplEncoder *p = NULL;
   try {
+    util_encode::sanitize_qp(qp, qp_min, qp_max);
     p = new VplEncoder(handle, luid, dataFormat, w, h, kbs, framerate,
-                       gop);
+                       gop, rc, qp, qp_min, qp_max);
     if (!p) {
       return NULL;
     }
@@ -633,7 +669,8 @@ int mfx_encode(void *encoder, ID3D11Texture2D *tex, EncodeCallback callback,
 int mfx_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, int32_t *outDescNum,
                     DataFormat dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
-                    int32_t gop, const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount) {
+                    int32_t gop, int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max,
+                    const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount) {
   try {
     Adapters adapters;
     if (!adapters.Init(ADAPTER_VENDOR_INTEL))
@@ -647,7 +684,7 @@ int mfx_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, 
       
       VplEncoder *e = (VplEncoder *)mfx_new_encoder(
           (void *)adapter.get()->device_.Get(), currentLuid,
-          dataFormat, width, height, kbs, framerate, gop);
+          dataFormat, width, height, kbs, framerate, gop, rc, qp, qp_min, qp_max);
       if (!e)
         continue;
       if (e->native_->EnsureTexture(e->width_, e->height_)) {
@@ -684,15 +721,64 @@ int mfx_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, 
 int mfx_set_bitrate(void *encoder, int32_t kbs) {
   try {
     VplEncoder *p = (VplEncoder *)encoder;
+    if (p->rc_ == RC_CQP) return 0;
     mfxStatus sts = MFX_ERR_NONE;
     // https://github.com/GStreamer/gstreamer/blob/e19428a802c2f4ee9773818aeb0833f93509a1c0/subprojects/gst-plugins-bad/sys/qsv/gstqsvencoder.cpp#L1312
     p->kbs_ = kbs;
     p->mfxENC_->GetVideoParam(&p->mfxEncParams_);
-    p->mfxEncParams_.mfx.TargetKbps = kbs;
-    p->mfxEncParams_.mfx.MaxKbps = kbs;
+    int32_t maxKbps = (p->rc_ == RC_VBR)
+        ? (int32_t)(util_encode::calc_vbr_max_rate((int64_t)kbs * 1000) / 1000)
+        : kbs;
+    int32_t topKbps = (maxKbps > kbs) ? maxKbps : kbs;
+    mfxU16 brc_mul = (topKbps > 0xFFFF)
+        ? (mfxU16)((topKbps + 0xFFFE) / 0xFFFF) : 1;
+    p->mfxEncParams_.mfx.BRCParamMultiplier = brc_mul;
+    p->mfxEncParams_.mfx.TargetKbps = (mfxU16)(kbs / brc_mul);
+    p->mfxEncParams_.mfx.MaxKbps = (mfxU16)(maxKbps / brc_mul);
     sts = p->mfxENC_->Reset(&p->mfxEncParams_);
-    if (sts != MFX_ERR_NONE) {
-      LOG_ERROR(std::string("reset failed, sts=") + std::to_string(sts));
+    if (sts > MFX_ERR_NONE) {
+      LOG_WARN(std::string("set bitrate reset warning, sts=") + std::to_string(sts));
+    } else if (sts < MFX_ERR_NONE) {
+      LOG_ERROR(std::string("set bitrate reset failed, sts=") + std::to_string(sts));
+      return -1;
+    }
+    return 0;
+  } catch (const std::exception &e) {
+    LOG_ERROR(std::string("Exception: ") + e.what());
+  }
+  return -1;
+}
+
+int mfx_set_qp(void *encoder, int32_t qp, int32_t qp_min, int32_t qp_max) {
+  try {
+    VplEncoder *p = (VplEncoder *)encoder;
+    if (p->rc_ != RC_CQP) return 0;
+    util_encode::sanitize_qp(qp, qp_min, qp_max);
+    mfxStatus sts = MFX_ERR_NONE;
+    p->qp_ = qp;
+    p->qp_min_ = qp_min;
+    p->qp_max_ = qp_max;
+    p->mfxENC_->GetVideoParam(&p->mfxEncParams_);
+    p->mfxEncParams_.mfx.QPI = qp;
+    p->mfxEncParams_.mfx.QPP = qp;
+    p->mfxEncParams_.mfx.QPB = qp;
+    if (qp_min > 0) {
+      mfxU16 v = qp_min > 51 ? 51 : qp_min;
+      p->coding_option2_.MinQPI = v;
+      p->coding_option2_.MinQPP = v;
+      p->coding_option2_.MinQPB = v;
+    }
+    if (qp_max > 0) {
+      mfxU16 v = qp_max > 51 ? 51 : qp_max;
+      p->coding_option2_.MaxQPI = v;
+      p->coding_option2_.MaxQPP = v;
+      p->coding_option2_.MaxQPB = v;
+    }
+    sts = p->mfxENC_->Reset(&p->mfxEncParams_);
+    if (sts > MFX_ERR_NONE) {
+      LOG_WARN(std::string("set qp reset warning, sts=") + std::to_string(sts));
+    } else if (sts < MFX_ERR_NONE) {
+      LOG_ERROR(std::string("set qp reset failed, sts=") + std::to_string(sts));
       return -1;
     }
     return 0;

--- a/cpp/mfx/mfx_ffi.h
+++ b/cpp/mfx/mfx_ffi.h
@@ -8,7 +8,8 @@ int mfx_driver_support();
 
 void *mfx_new_encoder(void *handle, int64_t luid,
                       int32_t dataFormat, int32_t width, int32_t height,
-                      int32_t kbs, int32_t framerate, int32_t gop);
+                      int32_t kbs, int32_t framerate, int32_t gop,
+                      int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max);
 
 int mfx_encode(void *encoder, void *tex, EncodeCallback callback, void *obj,
                int64_t ms);
@@ -26,13 +27,16 @@ int mfx_destroy_decoder(void *decoder);
 int mfx_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, int32_t *outDescNum,
                     int32_t dataFormat, int32_t width,
                     int32_t height, int32_t kbs, int32_t framerate,
-                    int32_t gop, const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
+                    int32_t gop, int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max,
+                    const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
 
 int mfx_test_decode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, int32_t *outDescNum,
                     int32_t dataFormat, uint8_t *data,
                     int32_t length, const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
 
 int mfx_set_bitrate(void *encoder, int32_t kbs);
+
+int mfx_set_qp(void *encoder, int32_t qp, int32_t qp_min, int32_t qp_max);
 
 int mfx_set_framerate(void *encoder, int32_t framerate);
 

--- a/cpp/nv/nv_encode.cpp
+++ b/cpp/nv/nv_encode.cpp
@@ -72,13 +72,17 @@ public:
   int32_t kbs_;
   int32_t framerate_;
   int32_t gop_;
+  int32_t rc_;
+  int32_t qp_;
+  int32_t qp_min_;
+  int32_t qp_max_;
   bool full_range_ = false;
   bool bt709_ = false;
   NV_ENC_CONFIG encodeConfig_ = {0};
 
   NvencEncoder(void *handle, int64_t luid, DataFormat dataFormat,
                int32_t width, int32_t height, int32_t kbs, int32_t framerate,
-               int32_t gop) {
+               int32_t gop, int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max) {
     handle_ = handle;
     luid_ = luid;
     dataFormat_ = dataFormat;
@@ -87,6 +91,10 @@ public:
     kbs_ = kbs;
     framerate_ = framerate;
     gop_ = gop;
+    rc_ = rc;
+    qp_ = qp;
+    qp_min_ = qp_min;
+    qp_max_ = qp_max;
 
     load_driver(&cuda_dl_, &nvenc_dl_);
   }
@@ -146,8 +154,6 @@ public:
     initializeParams.encodeConfig->frameIntervalP = 1;
     initializeParams.encodeConfig->rcParams.lookaheadDepth = 0;
 
-    // bitrate
-    initializeParams.encodeConfig->rcParams.averageBitRate = kbs_ * 1000;
     // framerate
     initializeParams.frameRateNum = framerate_;
     initializeParams.frameRateDen = 1;
@@ -155,8 +161,24 @@ public:
     initializeParams.encodeConfig->gopLength =
         (gop_ > 0 && gop_ < MAX_GOP) ? gop_ : NVENC_INFINITE_GOPLENGTH;
     // rc method
-    initializeParams.encodeConfig->rcParams.rateControlMode =
-        NV_ENC_PARAMS_RC_CBR;
+    if (rc_ == RC_CQP) {
+      initializeParams.encodeConfig->rcParams.rateControlMode =
+          NV_ENC_PARAMS_RC_CONSTQP;
+      initializeParams.encodeConfig->rcParams.constQP.qpInterP = qp_;
+      initializeParams.encodeConfig->rcParams.constQP.qpIntra = qp_;
+      initializeParams.encodeConfig->rcParams.constQP.qpInterB = qp_;
+    } else {
+      if (kbs_ <= 0) kbs_ = DEFAULT_KBS;
+      initializeParams.encodeConfig->rcParams.averageBitRate = kbs_ * 1000;
+      initializeParams.encodeConfig->rcParams.rateControlMode =
+          (rc_ == RC_VBR) ? NV_ENC_PARAMS_RC_VBR : NV_ENC_PARAMS_RC_CBR;
+      if (rc_ == RC_VBR) {
+        initializeParams.encodeConfig->rcParams.maxBitRate =
+            (uint32_t)util_encode::calc_vbr_max_rate(kbs_ * 1000);
+      } else {
+        initializeParams.encodeConfig->rcParams.maxBitRate = kbs_ * 1000;
+      }
+    }
     // color
     if (dataFormat_ == H264) {
       setup_h264(initializeParams.encodeConfig);
@@ -338,11 +360,13 @@ int nv_destroy_encoder(void *encoder) {
 
 void *nv_new_encoder(void *handle, int64_t luid, DataFormat dataFormat,
                      int32_t width, int32_t height, int32_t kbs,
-                     int32_t framerate, int32_t gop) {
+                     int32_t framerate, int32_t gop,
+                     int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max) {
   NvencEncoder *e = NULL;
   try {
+    util_encode::sanitize_qp(qp, qp_min, qp_max);
     e = new NvencEncoder(handle, luid, dataFormat, width, height, kbs,
-                         framerate, gop);
+                         framerate, gop, rc, qp, qp_min, qp_max);
     if (!e->init()) {
       goto _exit;
     }
@@ -392,7 +416,8 @@ int nv_encode(void *encoder, void *texture, EncodeCallback callback, void *obj,
 int nv_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, int32_t *outDescNum,
                    DataFormat dataFormat, int32_t width,
                    int32_t height, int32_t kbs, int32_t framerate,
-                   int32_t gop, const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount) {
+                   int32_t gop, int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max,
+                   const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount) {
   try {
     Adapters adapters;
     if (!adapters.Init(ADAPTER_VENDOR_NVIDIA))
@@ -406,7 +431,7 @@ int nv_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, i
 
       NvencEncoder *e = (NvencEncoder *)nv_new_encoder(
           (void *)adapter.get()->device_.Get(), currentLuid,
-          dataFormat, width, height, kbs, framerate, gop);
+          dataFormat, width, height, kbs, framerate, gop, rc, qp, qp_min, qp_max);
       if (!e)
         continue;
       if (e->native_->EnsureTexture(e->width_, e->height_)) {
@@ -440,12 +465,35 @@ int nv_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, i
 int nv_set_bitrate(void *e, int32_t kbs) {
   try {
     RECONFIGURE_HEAD
+    if (enc->rc_ == RC_CQP) return 0;
     params.reInitEncodeParams.encodeConfig->rcParams.averageBitRate =
         kbs * 1000;
+    if (enc->rc_ == RC_VBR) {
+      params.reInitEncodeParams.encodeConfig->rcParams.maxBitRate =
+          (uint32_t)util_encode::calc_vbr_max_rate(kbs * 1000);
+    } else {
+      params.reInitEncodeParams.encodeConfig->rcParams.maxBitRate = kbs * 1000;
+    }
     RECONFIGURE_TAIL
   } catch (const std::exception &e) {
     LOG_ERROR(std::string("set bitrate to ") + std::to_string(kbs) +
               "k failed: " + e.what());
+  }
+  return -1;
+}
+
+int nv_set_qp(void *e, int32_t qp, int32_t qp_min, int32_t qp_max) {
+  try {
+    RECONFIGURE_HEAD
+    if (enc->rc_ != RC_CQP) return 0;
+    util_encode::sanitize_qp(qp, qp_min, qp_max);
+    params.reInitEncodeParams.encodeConfig->rcParams.constQP.qpInterP = qp;
+    params.reInitEncodeParams.encodeConfig->rcParams.constQP.qpIntra = qp;
+    params.reInitEncodeParams.encodeConfig->rcParams.constQP.qpInterB = qp;
+    RECONFIGURE_TAIL
+  } catch (const std::exception &e) {
+    LOG_ERROR(std::string("set qp to ") + std::to_string(qp) +
+              " failed: " + e.what());
   }
   return -1;
 }

--- a/cpp/nv/nv_ffi.h
+++ b/cpp/nv/nv_ffi.h
@@ -10,7 +10,8 @@ int nv_decode_driver_support();
 
 void *nv_new_encoder(void *handle, int64_t luid,
                      int32_t dataFormat, int32_t width, int32_t height,
-                     int32_t bitrate, int32_t framerate, int32_t gop);
+                     int32_t bitrate, int32_t framerate, int32_t gop,
+                     int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max);
 
 int nv_encode(void *encoder, void *tex, EncodeCallback callback, void *obj,
               int64_t ms);
@@ -27,6 +28,7 @@ int nv_destroy_decoder(void *decoder);
 int nv_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, int32_t *outDescNum,
                    int32_t dataFormat, int32_t width,
                    int32_t height, int32_t kbs, int32_t framerate, int32_t gop,
+                   int32_t rc, int32_t qp, int32_t qp_min, int32_t qp_max,
                    const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
 
 int nv_test_decode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, int32_t *outDescNum,
@@ -34,6 +36,8 @@ int nv_test_decode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, i
                    int32_t length, const int64_t *excludedLuids, const int32_t *excludeFormats, int32_t excludeCount);
 
 int nv_set_bitrate(void *encoder, int32_t kbs);
+
+int nv_set_qp(void *encoder, int32_t qp, int32_t qp_min, int32_t qp_max);
 
 int nv_set_framerate(void *encoder, int32_t framerate);
 

--- a/examples/align.rs
+++ b/examples/align.rs
@@ -5,7 +5,7 @@ use hwcodec::{
     vram::{DynamicContext, FeatureContext},
 };
 use hwcodec::{
-    common::{DataFormat, Quality::*, RateControl::*},
+    common::{DataFormat, RateControl::*},
     ffmpeg::AVPixelFormat::*,
     ffmpeg_ram::{
         decode::{DecodeContext, Decoder},
@@ -36,10 +36,10 @@ fn setup_ram(max_align: i32) {
             fps: 30,
             gop: 60,
             rc: RC_CBR,
-            quality: Quality_Default,
             kbs: 0,
-            q: -1,
-            thread_count: 1,
+            qp: -1,
+            qp_min: 0,
+            qp_max: 0,
         },
         None,
     );
@@ -99,13 +99,13 @@ fn test_ram(width: i32, height: i32, encode_info: CodecInfo, decode_info: CodecI
         height,
         pixfmt: AV_PIX_FMT_NV12,
         align: 0,
-        kbs: 0,
+        kbs: 2000,
         fps: 30,
         gop: 60,
-        quality: Quality_Default,
         rc: RC_CBR,
-        thread_count: 1,
-        q: -1,
+        qp: 28,
+        qp_min: 22,
+        qp_max: 34,
     };
     let decode_ctx = DecodeContext {
         name: decode_info.name.clone(),
@@ -143,6 +143,10 @@ fn setup_vram(max_align: i32) {
         kbitrate: 1000,
         framerate: 30,
         gop: MAX_GOP as _,
+        qp: 0,
+        qp_min: 0,
+        qp_max: 0,
+        rc: RC_CQP,
     });
     let decoders = hwcodec::vram::decode::available();
 
@@ -192,6 +196,10 @@ fn test_vram(
             kbitrate: 1000,
             framerate: 30,
             gop: MAX_GOP as _,
+            qp: 28,
+            qp_min: 22,
+            qp_max: 34,
+            rc: RC_CQP,
         },
     };
     let mut encoder = hwcodec::vram::encode::Encoder::new(encode_ctx).unwrap();

--- a/examples/available.rs
+++ b/examples/available.rs
@@ -1,6 +1,6 @@
 use env_logger::{init_from_env, Env, DEFAULT_FILTER_ENV};
 use hwcodec::{
-    common::{get_gpu_signature, Quality::*, RateControl::*},
+    common::{get_gpu_signature, RateControl::*},
     ffmpeg::AVPixelFormat,
     ffmpeg_ram::{
         decode::Decoder,
@@ -34,10 +34,10 @@ fn ram() {
         kbs: 1000,
         fps: 30,
         gop: i32::MAX,
-        quality: Quality_Default,
-        rc: RC_CBR,
-        q: -1,
-        thread_count: 1,
+        rc: RC_VBR,
+        qp: 28,
+        qp_min: 22,
+        qp_max: 34,
     };
     let encoders = Encoder::available_encoders(ctx.clone(), None);
     encoders.iter().map(|e| println!("{:?}", e)).count();
@@ -58,7 +58,11 @@ fn vram() {
         kbitrate: 5000,
         framerate: 30,
         gop: MAX_GOP as _,
+        qp: 28,
+        qp_min: 22,
+        qp_max: 34,
         device: None,
+        rc: RC_VBR,
     });
     encoders.iter().map(|e| println!("{:?}", e)).count();
     println!("decoders:");

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,6 +1,6 @@
 use env_logger::{init_from_env, Env, DEFAULT_FILTER_ENV};
 use hwcodec::{
-    common::{Quality::*, RateControl::*},
+    common::RateControl::*,
     ffmpeg::AVPixelFormat,
     ffmpeg_ram::{
         decode::{DecodeContext, Decoder},
@@ -25,10 +25,10 @@ fn main() {
         kbs: 5000,
         fps: 30,
         gop: 60,
-        quality: Quality_Default,
-        rc: RC_DEFAULT,
-        thread_count: 4,
-        q: -1,
+        rc: RC_CQP,
+        qp: 28,
+        qp_min: 22,
+        qp_max: 34,
     };
     let yuv_count = 10;
     println!("benchmark");

--- a/examples/codec.rs
+++ b/examples/codec.rs
@@ -1,6 +1,6 @@
 use env_logger::{init_from_env, Env, DEFAULT_FILTER_ENV};
 use hwcodec::{
-    common::{Quality::*, RateControl::*},
+    common::RateControl::*,
     ffmpeg::{AVHWDeviceType::*, AVPixelFormat::*},
     ffmpeg_ram::{
         decode::{DecodeContext, Decoder},
@@ -26,10 +26,10 @@ fn main() {
         kbs: 0,
         fps: 30,
         gop: 60,
-        quality: Quality_Default,
-        rc: RC_DEFAULT,
-        thread_count: 4,
-        q: -1,
+        rc: RC_CQP,
+        qp: 28,
+        qp_min: 22,
+        qp_max: 34,
     };
     let decode_ctx = DecodeContext {
         name: String::from("hevc"),

--- a/examples/pipeline_vram.rs
+++ b/examples/pipeline_vram.rs
@@ -34,6 +34,10 @@ fn main() {
                 kbitrate: 5000,
                 framerate: 30,
                 gop: MAX_GOP as _,
+                qp: 28,
+                qp_min: 22,
+                qp_max: 34,
+                rc: hwcodec::common::RateControl::RC_CQP,
             },
         };
         let de_ctx = DecodeContext {

--- a/examples/resolution.rs
+++ b/examples/resolution.rs
@@ -1,6 +1,6 @@
 use env_logger::{init_from_env, Env, DEFAULT_FILTER_ENV};
 use hwcodec::{
-    common::{Quality::*, RateControl::*, MAX_GOP},
+    common::{RateControl::*, MAX_GOP},
     ffmpeg::{
         AVHWDeviceType::{self, *},
         AVPixelFormat::*,
@@ -83,10 +83,10 @@ fn decode_encode(
         kbs: 1_000,
         fps: 30,
         gop: MAX_GOP as _,
-        quality: Quality_Default,
-        rc: RC_DEFAULT,
-        thread_count: 4,
-        q: -1,
+        rc: RC_CQP,
+        qp: 28,
+        qp_min: 22,
+        qp_max: 34,
     };
     let mut video_encoder = Encoder::new(enc_ctx).unwrap();
     let mut encode_file =

--- a/src/ffmpeg_ram/encode.rs
+++ b/src/ffmpeg_ram/encode.rs
@@ -1,12 +1,13 @@
 use crate::{
     common::{
         DataFormat::{self, *},
-        Quality, RateControl, TEST_TIMEOUT_MS,
+        RateControl, TEST_TIMEOUT_MS,
     },
     ffmpeg::{init_av_log, AVPixelFormat},
     ffmpeg_ram::{
         ffmpeg_linesize_offset_length, ffmpeg_ram_encode, ffmpeg_ram_free_encoder,
-        ffmpeg_ram_new_encoder, ffmpeg_ram_set_bitrate, CodecInfo, AV_NUM_DATA_POINTERS,
+        ffmpeg_ram_new_encoder, ffmpeg_ram_set_bitrate, ffmpeg_ram_set_qp, CodecInfo,
+        AV_NUM_DATA_POINTERS,
     },
 };
 use log::trace;
@@ -32,10 +33,10 @@ pub struct EncodeContext {
     pub fps: i32,
     pub gop: i32,
     pub rc: RateControl,
-    pub quality: Quality,
     pub kbs: i32,
-    pub q: i32,
-    pub thread_count: i32,
+    pub qp: i32,
+    pub qp_min: i32,
+    pub qp_max: i32,
 }
 
 pub struct EncodeFrame {
@@ -87,10 +88,10 @@ impl Encoder {
                 ctx.fps,
                 ctx.gop,
                 ctx.rc as _,
-                ctx.quality as _,
                 ctx.kbs,
-                ctx.q,
-                ctx.thread_count,
+                ctx.qp,
+                ctx.qp_min,
+                ctx.qp_max,
                 gpu,
                 linesize.as_mut_ptr(),
                 offset.as_mut_ptr(),
@@ -143,6 +144,15 @@ impl Encoder {
 
     pub fn set_bitrate(&mut self, kbs: i32) -> Result<(), ()> {
         let ret = unsafe { ffmpeg_ram_set_bitrate(self.codec, kbs) };
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    pub fn set_qp(&mut self, qp: i32, qp_min: i32, qp_max: i32) -> Result<(), ()> {
+        let ret = unsafe { ffmpeg_ram_set_qp(self.codec, qp, qp_min, qp_max) };
         if ret == 0 {
             Ok(())
         } else {
@@ -315,76 +325,31 @@ impl Encoder {
                     ..ctx
                 };
 
-                match Encoder::new(c) {
-                    Ok(mut encoder) => {
-                        debug!("Encoder {} created successfully", codec.name);
-                        let mut passed = false;
-                        let mut last_err: Option<i32> = None;
+                if !Encoder::test_encode_once(c.clone(), &yuv) {
+                    continue;
+                }
 
-                        let max_attempts = if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
-                            3
-                        } else {
-                            1
-                        };
-                        for attempt in 0..max_attempts {
-                            let pts = (attempt as i64) * 33; // 33ms is an approximation for 30 FPS (1000 / 30)
-                            let start = std::time::Instant::now();
-                            match encoder.encode(&yuv, pts) {
-                                Ok(frames) => {
-                                    let elapsed = start.elapsed().as_millis();
+                let needs_cqp_test = (codec.name.contains("qsv")
+                    || codec.name.contains("nvenc")
+                    || codec.name.contains("amf"))
+                    && ctx.rc != RateControl::RC_CQP;
 
-                                    if frames.len() == 1 {
-                                        if frames[0].key == 1 && elapsed < TEST_TIMEOUT_MS as _ {
-                                            debug!(
-                                                "Encoder {} test passed on attempt {}",
-                                                codec.name, attempt + 1
-                                            );
-                                            res.push(codec.clone());
-                                            passed = true;
-                                            break;
-                                        } else {
-                                            debug!(
-                                                "Encoder {} test failed on attempt {} - key: {}, timeout: {}ms",
-                                                codec.name,
-                                                attempt + 1,
-                                                frames[0].key,
-                                                elapsed
-                                            );
-                                        }
-                                    } else {
-                                        debug!(
-                                            "Encoder {} test failed on attempt {} - wrong frame count: {}",
-                                            codec.name,
-                                            attempt + 1,
-                                            frames.len()
-                                        );
-                                    }
-                                }
-                                Err(err) => {
-                                    last_err = Some(err);
-                                    debug!(
-                                        "Encoder {} test attempt {} returned error: {}",
-                                        codec.name,
-                                        attempt + 1,
-                                        err
-                                    );
-                                }
-                            }
-                        }
-
-                        if !passed {
-                            debug!(
-                                "Encoder {} test failed after retries{}",
-                                codec.name,
-                                last_err
-                                    .map(|e| format!(" (last err: {})", e))
-                                    .unwrap_or_default()
-                            );
-                        }
+                if needs_cqp_test {
+                    let cqp_c = EncodeContext {
+                        rc: RateControl::RC_CQP,
+                        ..c
+                    };
+                    if Encoder::test_encode_once(cqp_c, &yuv) {
+                        debug!(
+                            "Encoder {} passed both original and CQP tests",
+                            codec.name
+                        );
+                        res.push(codec.clone());
+                    } else {
+                        debug!("Encoder {} CQP test failed, skipping", codec.name);
                     }
-                    Err(_) => {
-                        debug!("Failed to create encoder {}", codec.name);
-                    }
+                } else {
+                    res.push(codec.clone());
                 }
             }
         } else {
@@ -392,6 +357,64 @@ impl Encoder {
         }
 
         res
+    }
+
+    fn test_encode_once(ctx: EncodeContext, yuv: &[u8]) -> bool {
+        use log::debug;
+        match Encoder::new(ctx.clone()) {
+            Ok(mut encoder) => {
+                debug!("Encoder {} (rc={:?}) created successfully", ctx.name, ctx.rc);
+                let max_attempts =
+                    if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+                        3
+                    } else {
+                        1
+                    };
+                for attempt in 0..max_attempts {
+                    let pts = (attempt as i64) * 33;
+                    let start = std::time::Instant::now();
+                    match encoder.encode(yuv, pts) {
+                        Ok(frames) => {
+                            let elapsed = start.elapsed().as_millis();
+                            if frames.len() == 1 {
+                                if frames[0].key == 1 && elapsed < TEST_TIMEOUT_MS as _ {
+                                    debug!(
+                                        "Encoder {} (rc={:?}) test passed on attempt {}",
+                                        ctx.name, ctx.rc, attempt + 1
+                                    );
+                                    return true;
+                                } else {
+                                    debug!(
+                                        "Encoder {} (rc={:?}) test failed on attempt {} - key: {}, timeout: {}ms",
+                                        ctx.name, ctx.rc, attempt + 1, frames[0].key, elapsed
+                                    );
+                                }
+                            } else {
+                                debug!(
+                                    "Encoder {} (rc={:?}) test failed on attempt {} - wrong frame count: {}",
+                                    ctx.name, ctx.rc, attempt + 1, frames.len()
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            debug!(
+                                "Encoder {} (rc={:?}) test attempt {} returned error: {}",
+                                ctx.name, ctx.rc, attempt + 1, err
+                            );
+                        }
+                    }
+                }
+                debug!(
+                    "Encoder {} (rc={:?}) test failed after retries",
+                    ctx.name, ctx.rc
+                );
+                false
+            }
+            Err(_) => {
+                debug!("Failed to create encoder {} (rc={:?})", ctx.name, ctx.rc);
+                false
+            }
+        }
     }
 
     fn dummy_yuv(ctx: EncodeContext) -> Result<Vec<u8>, ()> {

--- a/src/vram/amf.rs
+++ b/src/vram/amf.rs
@@ -16,6 +16,7 @@ pub fn encode_calls() -> EncodeCalls {
         destroy: amf_destroy_encoder,
         test: amf_test_encode,
         set_bitrate: amf_set_bitrate,
+        set_qp: amf_set_qp,
         set_framerate: amf_set_framerate,
     }
 }

--- a/src/vram/encode.rs
+++ b/src/vram/encode.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::Driver::*,
+    common::{Driver::*, RateControl},
     ffmpeg::init_av_log,
     vram::{
         amf, ffmpeg, inner::EncodeCalls, mfx, nv, DynamicContext, EncodeContext, FeatureContext,
@@ -42,6 +42,10 @@ impl Encoder {
                 ctx.d.kbitrate,
                 ctx.d.framerate,
                 ctx.d.gop,
+                ctx.d.rc as i32,
+                ctx.d.qp,
+                ctx.d.qp_min,
+                ctx.d.qp_max,
             );
             if codec.is_null() {
                 return Err(());
@@ -87,6 +91,15 @@ impl Encoder {
     pub fn set_bitrate(&mut self, kbs: i32) -> Result<(), i32> {
         unsafe {
             match (self.calls.set_bitrate)(self.codec, kbs) {
+                0 => Ok(()),
+                err => Err(err),
+            }
+        }
+    }
+
+    pub fn set_qp(&mut self, qp: i32, qp_min: i32, qp_max: i32) -> Result<(), i32> {
+        unsafe {
+            match (self.calls.set_qp)(self.codec, qp, qp_min, qp_max) {
                 0 => Ok(()),
                 err => Err(err),
             }
@@ -192,6 +205,8 @@ pub fn available(d: DynamicContext) -> Vec<FeatureContext> {
             .map(|(luid, format)| (*luid, *format))
             .unzip();
 
+
+        // Test with original rc
         let result = unsafe {
             test(
                 luids.as_mut_ptr(),
@@ -204,42 +219,112 @@ pub fn available(d: DynamicContext) -> Vec<FeatureContext> {
                 input.d.kbitrate,
                 input.d.framerate,
                 input.d.gop,
+                input.d.rc as i32,
+                input.d.qp,
+                input.d.qp_min,
+                input.d.qp_max,
                 excluded_luids.as_ptr(),
                 exclude_formats.as_ptr(),
                 exclude_luid_formats.len() as i32,
             )
         };
 
-        if result == 0 {
-            if desc_count as usize <= luids.len() {
-                debug!(
-                    "vram encoder test passed: driver={:?}, adapters={}",
-                    input.f.driver, desc_count
-                );
-                for i in 0..desc_count as usize {
-                    let mut input = input.clone();
-                    input.f.luid = luids[i];
-                    input.f.vendor = match vendors[i] {
-                        0 => NV,
-                        1 => AMF,
-                        2 => MFX,
-                        _ => {
-                            log::error!(
-                                "Unexpected vendor value encountered: {}. Skipping.",
-                                vendors[i]
-                            );
-                            continue;
-                        },
-                    };
-                    exclude_luid_formats.push((luids[i], input.f.data_format as i32));
-                    outputs.push(input);
-                }
-            }
-        } else {
+        if result != 0 {
             debug!(
                 "vram encoder test failed: driver={:?}, error={}",
                 input.f.driver, result
             );
+            continue;
+        }
+
+        if desc_count as usize > luids.len() {
+            continue;
+        }
+
+        debug!(
+            "vram encoder original rc test passed: driver={:?}, adapters={}",
+            input.f.driver, desc_count
+        );
+
+        // Collect LUIDs that passed the original rc test
+        let mut original_passed: Vec<(i64, i32)> = Vec::new();
+        for i in 0..desc_count as usize {
+            original_passed.push((luids[i], vendors[i]));
+        }
+
+        // Test with CQP rc (skip if original rc is already CQP)
+        let cqp_passed_luids: Option<Vec<i64>> = if input.d.rc == RateControl::RC_CQP {
+            None
+        } else {
+            let mut cqp_luids: Vec<i64> = vec![0; crate::vram::MAX_ADATERS];
+            let mut cqp_vendors: Vec<i32> = vec![0; crate::vram::MAX_ADATERS];
+            let mut cqp_desc_count: i32 = 0;
+
+            let cqp_result = unsafe {
+                test(
+                    cqp_luids.as_mut_ptr(),
+                    cqp_vendors.as_mut_ptr(),
+                    cqp_luids.len() as _,
+                    &mut cqp_desc_count,
+                    input.f.data_format as i32,
+                    input.d.width,
+                    input.d.height,
+                    input.d.kbitrate,
+                    input.d.framerate,
+                    input.d.gop,
+                    RateControl::RC_CQP as i32,
+                    input.d.qp,
+                    input.d.qp_min,
+                    input.d.qp_max,
+                    excluded_luids.as_ptr(),
+                    exclude_formats.as_ptr(),
+                    exclude_luid_formats.len() as i32,
+                )
+            };
+
+            if cqp_result == 0 && cqp_desc_count as usize <= cqp_luids.len() {
+                debug!(
+                    "vram encoder CQP test passed: driver={:?}, adapters={}",
+                    input.f.driver, cqp_desc_count
+                );
+                Some(cqp_luids[..cqp_desc_count as usize].to_vec())
+            } else {
+                debug!(
+                    "vram encoder CQP test failed: driver={:?}, error={}",
+                    input.f.driver, cqp_result
+                );
+                Some(vec![])
+            }
+        };
+
+        // Only keep LUIDs that passed both tests
+        for (luid, vendor) in original_passed {
+            if let Some(ref cqp_luids) = cqp_passed_luids {
+                if !cqp_luids.contains(&luid) {
+                    debug!(
+                        "vram encoder CQP test not passed for luid={}, skipping",
+                        luid
+                    );
+                    continue;
+                }
+            }
+
+            let mut input = input.clone();
+            input.f.luid = luid;
+            input.f.vendor = match vendor {
+                0 => NV,
+                1 => AMF,
+                2 => MFX,
+                _ => {
+                    log::error!(
+                        "Unexpected vendor value encountered: {}. Skipping.",
+                        vendor
+                    );
+                    continue;
+                },
+            };
+            exclude_luid_formats.push((luid, input.f.data_format as i32));
+            outputs.push(input);
         }
     }
 

--- a/src/vram/ffmpeg.rs
+++ b/src/vram/ffmpeg.rs
@@ -16,6 +16,7 @@ pub fn encode_calls() -> EncodeCalls {
         destroy: ffmpeg_vram_destroy_encoder,
         test: ffmpeg_vram_test_encode,
         set_bitrate: ffmpeg_vram_set_bitrate,
+        set_qp: ffmpeg_vram_set_qp,
         set_framerate: ffmpeg_vram_set_framerate,
     }
 }

--- a/src/vram/inner.rs
+++ b/src/vram/inner.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::common::{DataFormat, DecodeCallback, EncodeCallback};
 use std::os::raw::{c_int, c_void};
 
@@ -10,6 +12,10 @@ pub type NewEncoderCall = unsafe extern "C" fn(
     bitrate: i32,
     framerate: i32,
     gop: i32,
+    rc: i32,
+    qp: i32,
+    qp_min: i32,
+    qp_max: i32,
 ) -> *mut c_void;
 
 pub type EncodeCall = unsafe extern "C" fn(
@@ -42,6 +48,10 @@ pub type TestEncodeCall = unsafe extern "C" fn(
     kbs: i32,
     framerate: i32,
     gop: i32,
+    rc: i32,
+    qp: i32,
+    qp_min: i32,
+    qp_max: i32,
     excludedLuids: *const i64,
     excludeFormats: *const i32,
     excludeCount: i32,
@@ -64,12 +74,16 @@ pub type IVCall = unsafe extern "C" fn(v: *mut c_void) -> c_int;
 
 pub type IVICall = unsafe extern "C" fn(v: *mut c_void, i: i32) -> c_int;
 
+pub type SetQpCall =
+    unsafe extern "C" fn(v: *mut c_void, qp: i32, qp_min: i32, qp_max: i32) -> c_int;
+
 pub struct EncodeCalls {
     pub new: NewEncoderCall,
     pub encode: EncodeCall,
     pub destroy: IVCall,
     pub test: TestEncodeCall,
     pub set_bitrate: IVICall,
+    pub set_qp: SetQpCall,
     pub set_framerate: IVICall,
 }
 pub struct DecodeCalls {

--- a/src/vram/mfx.rs
+++ b/src/vram/mfx.rs
@@ -16,6 +16,7 @@ pub fn encode_calls() -> EncodeCalls {
         destroy: mfx_destroy_encoder,
         test: mfx_test_encode,
         set_bitrate: mfx_set_bitrate,
+        set_qp: mfx_set_qp,
         set_framerate: mfx_set_framerate,
     }
 }

--- a/src/vram/mod.rs
+++ b/src/vram/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod nv;
 
 pub(crate) const MAX_ADATERS: usize = 16;
 
-use crate::common::{DataFormat, Driver};
+use crate::common::{DataFormat, Driver, RateControl};
 pub use serde;
 pub use serde_derive;
 use serde_derive::{Deserialize, Serialize};
@@ -31,6 +31,10 @@ pub struct DynamicContext {
     pub kbitrate: i32,
     pub framerate: i32,
     pub gop: i32,
+    pub rc: RateControl,
+    pub qp: i32,
+    pub qp_min: i32,
+    pub qp_max: i32,
 }
 
 unsafe impl Send for DynamicContext {}

--- a/src/vram/nv.rs
+++ b/src/vram/nv.rs
@@ -16,6 +16,7 @@ pub fn encode_calls() -> EncodeCalls {
         destroy: nv_destroy_encoder,
         test: nv_test_encode,
         set_bitrate: nv_set_bitrate,
+        set_qp: nv_set_qp,
         set_framerate: nv_set_framerate,
     }
 }


### PR DESCRIPTION
  - Add RateControl enum with CBR, VBR, CQP modes
  - Support qp, qp_min, qp_max parameters across AMF, NVENC, MFX, and FFmpeg encoders
  - Update FFI interfaces and Rust bindings accordingly
  - Bump version to 0.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added constant-QP (CQP) rate control mode support across all hardware encoders (NVIDIA, AMD, Intel, FFmpeg).
  * Introduced quantization parameter (QP) configuration with min/max bounds for fine-grained quality control.
  * Added runtime QP adjustment via new `set_qp()` API.

* **Refactor**
  * Modernized rate-control system; replaced legacy quality enum with explicit QP-based configuration.
  * Enhanced encoder discovery with improved validation testing.

* **Chores**
  * Version bump to 0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->