### PR TITLE
Fix building on Windows arm64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -135,7 +135,7 @@ mod ffmpeg {
                 format!("{}-{}", target_arch, target_os)
             }
         } else if target_os == "windows" {
-            "x64-windows-static".to_owned()
+            format!("{}-windows-static", target_arch)
         } else {
             format!("{}-{}", target_arch, target_os)
         };
@@ -155,7 +155,9 @@ mod ffmpeg {
         );
         {
             let mut static_libs = vec!["avcodec", "avutil", "avformat"];
-            if target_os == "windows" {
+            // Intel Quick Sync (libmfx/QSV) is x86/x64-only; FFmpeg is built without
+            // --enable-libmfx on arm64 (see res/vcpkg/ffmpeg/portfile.cmake), so don't link it there.
+            if target_os == "windows" && (target_arch == "x64" || target_arch == "x86") {
                 static_libs.push("libmfx");
             }
             static_libs


### PR DESCRIPTION
The current code is hardcoded to `x64-windows-static` if the `target_os` is set to `windows`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build configuration to correctly support multiple CPU architectures on Windows (x64, x86, arm64) instead of hardcoding a single target.
  * Ensured Intel Quick Sync support is only linked when appropriate for the target platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk-org/hwcodec/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->