### PR TITLE
fix: contain exceptions in mfx probe FFI to avoid FATAL_APP_EXIT crash

### DIFF
--- a/cpp/mfx/mfx_decode.cpp
+++ b/cpp/mfx/mfx_decode.cpp
@@ -416,6 +416,8 @@ void *mfx_new_decoder(void *device, int64_t luid, DataFormat codecID) {
     }
   } catch (const std::exception &e) {
     LOG_ERROR(std::string("new failed: ") + e.what());
+  } catch (...) {
+    LOG_ERROR(std::string("new failed: unknown exception"));
   }
 
   if (p) {
@@ -435,6 +437,8 @@ int mfx_decode(void *decoder, uint8_t *data, int len, DecodeCallback callback,
     }
   } catch (const std::exception &e) {
     LOG_ERROR(std::string("decode failed: ") + e.what());
+  } catch (...) {
+    LOG_ERROR(std::string("decode failed: unknown exception"));
   }
   return HWCODEC_ERR_COMMON;
 }
@@ -475,6 +479,8 @@ int mfx_test_decode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum,
     return 0;
   } catch (const std::exception &e) {
     std::cerr << e.what() << '\n';
+  } catch (...) {
+    LOG_ERROR(std::string("mfx_test_decode unknown exception"));
   }
   return -1;
 }

--- a/cpp/mfx/mfx_encode.cpp
+++ b/cpp/mfx/mfx_encode.cpp
@@ -578,8 +578,20 @@ private:
 extern "C" {
 
 int mfx_driver_support() {
-  MFXVideoSession session;
-  return InitSession(session) == MFX_ERR_NONE ? 0 : -1;
+  // Never let an exception escape this extern "C" boundary. On some Intel
+  // drivers MFXVideoSession::InitEx may throw (including non-std exceptions);
+  // letting it propagate out of C calls std::terminate -> abort ->
+  // __fastfail(FATAL_APP_EXIT) (0xc0000409 / subcode 7), crashing the host
+  // process during startup hardware-codec probing (rustdesk/rustdesk#15218).
+  try {
+    MFXVideoSession session;
+    return InitSession(session) == MFX_ERR_NONE ? 0 : -1;
+  } catch (const std::exception &e) {
+    LOG_ERROR(std::string("mfx_driver_support exception: ") + e.what());
+  } catch (...) {
+    LOG_ERROR(std::string("mfx_driver_support unknown exception"));
+  }
+  return -1;
 }
 
 int mfx_destroy_encoder(void *encoder) {
@@ -610,6 +622,8 @@ void *mfx_new_encoder(void *handle, int64_t luid,
     }
   } catch (const std::exception &e) {
     LOG_ERROR(std::string("Exception: ") + e.what());
+  } catch (...) {
+    LOG_ERROR(std::string("Unknown exception"));
   }
 
   if (p) {
@@ -626,6 +640,8 @@ int mfx_encode(void *encoder, ID3D11Texture2D *tex, EncodeCallback callback,
     return ((VplEncoder *)encoder)->encode(tex, callback, obj, ms);
   } catch (const std::exception &e) {
     LOG_ERROR(std::string("Exception: ") + e.what());
+  } catch (...) {
+    LOG_ERROR(std::string("Unknown exception"));
   }
   return -1;
 }
@@ -674,6 +690,8 @@ int mfx_test_encode(int64_t *outLuids, int32_t *outVendors, int32_t maxDescNum, 
 
   } catch (const std::exception &e) {
     LOG_ERROR(std::string("test failed: ") + e.what());
+  } catch (...) {
+    LOG_ERROR(std::string("test failed: unknown exception"));
   }
   return -1;
 }
@@ -698,6 +716,8 @@ int mfx_set_bitrate(void *encoder, int32_t kbs) {
     return 0;
   } catch (const std::exception &e) {
     LOG_ERROR(std::string("Exception: ") + e.what());
+  } catch (...) {
+    LOG_ERROR(std::string("Unknown exception"));
   }
   return -1;
 }


### PR DESCRIPTION

On some Intel drivers the Media SDK probe throws during startup hardware-codec detection. mfx_driver_support() had no try/catch at all, and the other mfx extern "C" entries caught only std::exception, so a non-std throw escaped the C boundary -> std::terminate -> abort -> __fastfail(FATAL_APP_EXIT) (0xc0000409, subcode 7), crashing the host process before its window appears.

Guard mfx_driver_support() and add a catch(...) arm to every mfx encode/decode extern "C" entry so a failed Intel probe degrades to "codec unavailable" instead of aborting the process.

Addresses the Windows startup crash reported in rustdesk/rustdesk#15218.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of hardware video encoding and decoding operations with enhanced exception handling to prevent unexpected crashes.
  * Strengthened error detection and logging during codec operations to better diagnose issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->