### PR TITLE
Support CQP rate control for FFmpeg VAAPI encoders

### DIFF
--- a/cpp/common/util.cpp
+++ b/cpp/common/util.cpp
@@ -238,7 +238,8 @@ bool set_rate_control(AVCodecContext *c, const std::string &name, int rc,
         }
         if (name.find("vaapi") != std::string::npos && rc == RC_CQ) {
           constexpr int default_qp = 23;
-          const int qp = q >= 0 && q <= 51 ? q : default_qp;
+          // FFmpeg treats qp = 0 as unspecified, not as an explicit QP.
+          const int qp = q > 0 && q <= 51 ? q : default_qp;
           ret = av_opt_set_int(c->priv_data, "qp", qp, 0);
           if (ret < 0) {
             LOG_ERROR(std::string("vaapi set opt qp failed, ret = ") +

--- a/cpp/common/util.cpp
+++ b/cpp/common/util.cpp
@@ -239,7 +239,9 @@ bool set_rate_control(AVCodecContext *c, const std::string &name, int rc,
         if (name.find("vaapi") != std::string::npos && rc == RC_CQ) {
           constexpr int default_qp = 23;
           // FFmpeg treats qp = 0 as unspecified, not as an explicit QP.
-          const int qp = q > 0 && q <= 51 ? q : default_qp;
+          // Negative values are also unspecified in EncodeContext. Positive
+          // values are validated by the codec-specific FFmpeg option.
+          const int qp = q > 0 ? q : default_qp;
           ret = av_opt_set_int(c->priv_data, "qp", qp, 0);
           if (ret < 0) {
             LOG_ERROR(std::string("vaapi set opt qp failed, ret = ") +

--- a/cpp/common/util.cpp
+++ b/cpp/common/util.cpp
@@ -214,6 +214,7 @@ bool set_rate_control(AVCodecContext *c, const std::string &name, int rc,
       {"mediacodec",
        "bitrate_mode",
        {{RC_CBR, "cbr"}, {RC_VBR, "vbr"}, {RC_CQ, "cq"}}},
+      {"vaapi", "rc_mode", {{RC_CQ, "CQP"}}},
       // {"videotoolbox", "constant_bit_rate", {{RC_CBR, "1"}}},
     };
 
@@ -233,6 +234,16 @@ bool set_rate_control(AVCodecContext *c, const std::string &name, int rc,
             if (q >= 0 && q <= 51) {
               c->global_quality = q;
             }
+          }
+        }
+        if (name.find("vaapi") != std::string::npos && rc == RC_CQ) {
+          constexpr int default_qp = 23;
+          const int qp = q >= 0 && q <= 51 ? q : default_qp;
+          ret = av_opt_set_int(c->priv_data, "qp", qp, 0);
+          if (ret < 0) {
+            LOG_ERROR(std::string("vaapi set opt qp failed, ret = ") +
+                      av_err2str(ret));
+            return false;
           }
         }
       }

--- a/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
@@ -236,7 +236,12 @@ public:
       return false;
     }
     // util_encode::set_quality(c_->priv_data, name_, quality_);
-    util_encode::set_rate_control(c_, name_, rc_, q_);
+    const bool rate_control_set =
+        util_encode::set_rate_control(c_, name_, rc_, q_);
+    if (!rate_control_set && name_.find("vaapi") != std::string::npos) {
+      LOG_ERROR(std::string("set_rate_control failed, name: ") + name_);
+      return false;
+    }
     util_encode::set_gpu(c_->priv_data, name_, gpu_);
     util_encode::force_hw(c_->priv_data, name_);
     util_encode::set_others(c_->priv_data, name_);

--- a/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
@@ -236,10 +236,7 @@ public:
       return false;
     }
     // util_encode::set_quality(c_->priv_data, name_, quality_);
-    if (!util_encode::set_rate_control(c_, name_, rc_, q_)) {
-      LOG_ERROR(std::string("set_rate_control failed, name: ") + name_);
-      return false;
-    }
+    util_encode::set_rate_control(c_, name_, rc_, q_);
     util_encode::set_gpu(c_->priv_data, name_, gpu_);
     util_encode::force_hw(c_->priv_data, name_);
     util_encode::set_others(c_->priv_data, name_);

--- a/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
+++ b/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
@@ -236,7 +236,10 @@ public:
       return false;
     }
     // util_encode::set_quality(c_->priv_data, name_, quality_);
-    util_encode::set_rate_control(c_, name_, rc_, q_);
+    if (!util_encode::set_rate_control(c_, name_, rc_, q_)) {
+      LOG_ERROR(std::string("set_rate_control failed, name: ") + name_);
+      return false;
+    }
     util_encode::set_gpu(c_->priv_data, name_, gpu_);
     util_encode::force_hw(c_->priv_data, name_);
     util_encode::set_others(c_->priv_data, name_);

--- a/src/ffmpeg_ram/encode.rs
+++ b/src/ffmpeg_ram/encode.rs
@@ -312,6 +312,13 @@ impl Encoder {
                 let c = EncodeContext {
                     name: codec.name.clone(),
                     mc_name: codec.mc_name.clone(),
+                    // RustDesk uses CQP for VAAPI; probing with a bitrate-based
+                    // mode would reject drivers that only support CQP.
+                    rc: if codec.name.contains("vaapi") {
+                        RateControl::RC_CQ
+                    } else {
+                        ctx.rc
+                    },
                     ..ctx
                 };
 

--- a/tests/vaapi_cqp.cpp
+++ b/tests/vaapi_cqp.cpp
@@ -1,0 +1,76 @@
+#include "common.h"
+#include "util.h"
+
+extern "C" {
+#include <libavutil/opt.h>
+}
+
+#include <cassert>
+#include <cstddef>
+#include <iostream>
+
+namespace gol {
+void error(const std::string &message) { std::cerr << message << '\n'; }
+}
+
+// Exercise the real AVOption writes without requiring a VAAPI device.
+struct Options {
+  const AVClass *av_class;
+  int rc_mode;
+  int qp;
+};
+
+static const AVOption options[] = {
+    {"rc_mode", nullptr, offsetof(Options, rc_mode), AV_OPT_TYPE_INT,
+     {.i64 = 0}, 0, 6, 0, "rc_mode"},
+    {"CQP", nullptr, 0, AV_OPT_TYPE_CONST, {.i64 = 1}, 0, 0, 0, "rc_mode"},
+    {"qp", nullptr, offsetof(Options, qp), AV_OPT_TYPE_INT, {.i64 = 0}, 0, 51},
+    {nullptr},
+};
+
+int main() {
+  AVClass av_class = {};
+  av_class.class_name = "VAAPI options test";
+  av_class.item_name = av_default_item_name;
+  av_class.option = options;
+  av_class.version = LIBAVUTIL_VERSION_INT;
+
+  Options priv = {&av_class, 0, 0};
+  AVCodecContext ctx = {};
+  ctx.priv_data = &priv;
+  ctx.bit_rate = 1000000;
+
+  for (const auto &name : {"h264_vaapi", "hevc_vaapi"}) {
+    for (int qp : {1, 16, 23, 26, 51}) {
+      av_opt_set_defaults(&priv);
+      assert(util_encode::set_rate_control(&ctx, name, RC_CQ, qp));
+      assert(priv.rc_mode == 1);
+      assert(priv.qp == qp);
+      assert(ctx.bit_rate == 1000000);
+    }
+    for (int qp : {-100, -1, 0, 52, 100}) {
+      av_opt_set_defaults(&priv);
+      assert(util_encode::set_rate_control(&ctx, name, RC_CQ, qp));
+      assert(priv.rc_mode == 1);
+      assert(priv.qp == 23);
+    }
+  }
+
+  // Explicit CQP configuration must not affect callers requesting other modes.
+  for (int rc : {RC_CBR, RC_VBR}) {
+    av_opt_set_defaults(&priv);
+    assert(util_encode::set_rate_control(&ctx, "h264_vaapi", rc, 16));
+    assert(priv.rc_mode == 0);
+    assert(priv.qp == 0);
+  }
+
+  // Missing options must be reported as failures, not as successful CQP setup.
+  AVOption mode_only[] = {options[0], options[1], {nullptr}};
+  av_class.option = mode_only;
+  assert(!util_encode::set_rate_control(&ctx, "h264_vaapi", RC_CQ, 23));
+  AVOption no_options[] = {{nullptr}};
+  av_class.option = no_options;
+  assert(!util_encode::set_rate_control(&ctx, "h264_vaapi", RC_CQ, 23));
+
+  std::cout << "VAAPI CQP option tests passed\n";
+}

--- a/tests/vaapi_cqp.cpp
+++ b/tests/vaapi_cqp.cpp
@@ -48,11 +48,16 @@ int main() {
       assert(priv.qp == qp);
       assert(ctx.bit_rate == 1000000);
     }
-    for (int qp : {-100, -1, 0, 52, 100}) {
+    for (int qp : {-100, -1, 0}) {
       av_opt_set_defaults(&priv);
       assert(util_encode::set_rate_control(&ctx, name, RC_CQ, qp));
       assert(priv.rc_mode == 1);
       assert(priv.qp == 23);
+    }
+    for (int qp : {52, 100}) {
+      av_opt_set_defaults(&priv);
+      assert(!util_encode::set_rate_control(&ctx, name, RC_CQ, qp));
+      assert(priv.rc_mode == 1);
     }
   }
 


### PR DESCRIPTION
## Summary

On an Intel iHD VAAPI system, h264_vaapi rejects the CBR configuration used by
the caller and reports:

> Driver does not support any RC mode compatible with selected options (supported modes: CQP).

The existing rate-control layer has a constant-quality mode for MediaCodec but
does not map it to VAAPI's rc_mode option. This change fills that gap and passes
a validated QP value to FFmpeg.

## Changes

- Map RC_CQ to rc_mode=CQP for VAAPI encoders.
- Pass a validated QP through FFmpeg's VAAPI encoder options.
- Preserve the behavior of other encoder backends.
- Return a clear failure if the VAAPI QP option cannot be applied.

## Validation

Tested on an Intel HD Graphics 530 using the Intel i915/iHD VAAPI stack.

- The matching CBR probe fails with the driver error above.
- The matching CQP probe succeeds with QP 23.
- The cleaned C++ source passes a syntax check against the FFmpeg headers used
  by the working RustDesk build.
- An end-to-end RustDesk session using the resulting VAAPI encoder became
  substantially smoother after software AV1 encoding was no longer selected.

## Related work

This is related to https://github.com/rustdesk-org/hwcodec/pull/40. That draft
adds broader rate-control and QP infrastructure; this contribution adds the
missing VAAPI-specific behavior without duplicating that refactor.

Downstream context is available in
https://github.com/rustdesk/rustdesk/pull/14294.

If maintainers prefer this change to land as part of the broader rate-control
work, I am happy to rebase it or provide the VAAPI implementation as a focused
follow-up commit.

## Scope

This PR does not change RustDesk UI behavior, Docker files, dependency
overrides, or distribution-specific build tooling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added VAAPI constant-quality rate control using CQP mode.
  - VAAPI encoding now applies requested quality through the `qp` setting, defaulting nonpositive values to 23.
  - VAAPI encoder probing automatically uses constant-quality mode.

- **Bug Fixes**
  - Improved handling of VAAPI quality values by validating positive settings and reporting unsupported configurations.
  - VAAPI initialization no longer stops solely because rate-control setup cannot be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->